### PR TITLE
Fix LinkOverlay crashing on certain tables with constrained links

### DIFF
--- a/src/main/js/components/table/VirtualTable.jsx
+++ b/src/main/js/components/table/VirtualTable.jsx
@@ -354,7 +354,8 @@ export default class VirtualTable extends PureComponent {
     //    return visibleCells[columnIndex];
   };
 
-  filterVisibleCells = (cell, columnId) => columnId === 0 || this.props.columns.at(columnId).visible;
+  filterVisibleCells = (cell, columnIdx) => columnIdx === 0
+    || (f.get("visible", this.props.columns.at(columnIdx)) && this.props.columns.at(columnIdx) !== this.props.columns.at(0));
 
   componentWillReceiveProps(next) {
     const newPropKeys = f.keys(next);

--- a/src/main/js/components/table/VirtualTable.jsx
+++ b/src/main/js/components/table/VirtualTable.jsx
@@ -354,6 +354,8 @@ export default class VirtualTable extends PureComponent {
     //    return visibleCells[columnIndex];
   };
 
+  // adding element with id:0 to columns collection results in duplicates
+  // https://github.com/AmpersandJS/ampersand-collection/issues/54
   filterVisibleCells = (cell, columnIdx) => columnIdx === 0
     || (f.get("visible", this.props.columns.at(columnIdx)) && this.props.columns.at(columnIdx) !== this.props.columns.at(0));
 


### PR DESCRIPTION
This is caused by a bug in ampersand-collection, reported in 2015 and still unfixed: https://github.com/AmpersandJS/ampersand-collection/issues/54