### PR TITLE
Workaround redraw problems

### DIFF
--- a/src/main/js/dispatcher/GlobalCellChangeListener.js
+++ b/src/main/js/dispatcher/GlobalCellChangeListener.js
@@ -63,6 +63,7 @@ Dispatcher.on("all", (...args) => {
     triggerCallbacks(...rest);
   }
 });
+// https://app.activecollab.com/116706/projects/2/tasks/2843
 // Dispatcher.on(ActionTypes.BROADCAST_DATA_CHANGE, triggerCallbacks);
 
 export {listenForCellChange, clearCallbacks};

--- a/src/main/js/dispatcher/GlobalCellChangeListener.js
+++ b/src/main/js/dispatcher/GlobalCellChangeListener.js
@@ -56,6 +56,13 @@ const triggerCallbacks = (payload) => {
   );
 };
 
-Dispatcher.on(ActionTypes.BROADCAST_DATA_CHANGE, triggerCallbacks);
+Dispatcher.on("all", (...args) => {
+  // window.devLog("An event was triggered:", ...args);
+  const [name, ...rest] = args;
+  if (name === ActionTypes.BROADCAST_DATA_CHANGE) {
+    triggerCallbacks(...rest);
+  }
+});
+// Dispatcher.on(ActionTypes.BROADCAST_DATA_CHANGE, triggerCallbacks);
 
 export {listenForCellChange, clearCallbacks};

--- a/src/main/js/models/helpers/changeCell.js
+++ b/src/main/js/models/helpers/changeCell.js
@@ -16,7 +16,7 @@ import Raven from "raven-js";
 import {remember} from "../../components/table/undo/tableHistory";
 
 async function changeCell({cell, value, options = {}}) {
-  window.devLog(`Changing ${cell.kind} cell ${cell.id} from`, cell.value, "to", (value.value || value));
+  window.devLog(`Changing ${cell.kind} cell ${cell.id} from`, cell.value, "to", f.getOr(value, "value", value));
   Raven.captureBreadcrumb({
     message: `Change cell ${cell.id}`,
     data: {

--- a/src/main/js/models/helpers/changeCell.js
+++ b/src/main/js/models/helpers/changeCell.js
@@ -16,7 +16,7 @@ import Raven from "raven-js";
 import {remember} from "../../components/table/undo/tableHistory";
 
 async function changeCell({cell, value, options = {}}) {
-  window.devLog(`Changing ${cell.kind} cell ${cell.id} from`, cell.value, "to", f.getOr(value, "value", value));
+  window.devLog(`Changing ${cell.kind} cell ${cell.id} from`, cell.value, "to", (f.isObject(value) ? value.value : value));
   Raven.captureBreadcrumb({
     message: `Change cell ${cell.id}`,
     data: {


### PR DESCRIPTION
A quick, hacky and hard-to-believe solution for ampersand-events not triggering the cell events in some cases.

Investigation is needed to find the cause of the problems.