### PR TITLE
Fix attachment history always showing "item was deleted"

### DIFF
--- a/src/app/components/history/HistoryBody.jsx
+++ b/src/app/components/history/HistoryBody.jsx
@@ -21,7 +21,7 @@ import {
   isOldEnough,
   matchesLangtag,
   matchesUser,
-  maybeAddLinkLabels,
+  maybeAddLabels,
   reduceRevisionHistory,
   valueMatchesFilter
 } from "./history-helpers";
@@ -59,7 +59,7 @@ const HistoryBody = props => {
       })
     })
       .then(f.prop("rows"))
-      .then(maybeAddLinkLabels(column, contentLangtag))
+      .then(maybeAddLabels(column, contentLangtag))
       .then(setRevisions)
       .catch(console.error);
   }, []);

--- a/src/app/components/history/differ.js
+++ b/src/app/components/history/differ.js
@@ -51,7 +51,10 @@ const calcLinkDiff = revision => {
   ];
 };
 
-const calcAttachmentDiff = ({ fullValue = [], prevContent = [] }, langtag) => {
+const calcAttachmentDiff = (
+  { fullValue = [], prevContent = [], currentDisplayValues },
+  langtag
+) => {
   const added = f.differenceBy("uuid", fullValue, prevContent);
   const removed = f.differenceBy("uuid", prevContent, fullValue);
   const unchanged = f.intersectionBy("uuid", prevContent, fullValue);
@@ -65,14 +68,17 @@ const calcAttachmentDiff = ({ fullValue = [], prevContent = [] }, langtag) => {
   return [
     ...removed.map(attachment => ({
       del: true,
-      value: retrieveDisplayValue(attachment)
+      value: retrieveDisplayValue(attachment),
+      currentDisplayValues
     })),
     ...added.map(attachment => ({
       add: true,
-      value: retrieveDisplayValue(attachment)
+      value: retrieveDisplayValue(attachment),
+      currentDisplayValues
     })),
     ...unchanged.map(attachment => ({
-      value: retrieveDisplayValue(attachment)
+      value: retrieveDisplayValue(attachment),
+      currentDisplayValues
     }))
   ];
 };


### PR DESCRIPTION
We also add current files' display values to the shared
link/attachment diff visualiser. We don't check if files have been
deleted since, because to do so we would need to fetch all files and
check for 404 responses, also we can not retrieve name changes this
way. This should not matter too much, as a file is either there, or it
isn't.