### PR TITLE
Support more editing styles

### DIFF
--- a/src/app/components/markdownEditor/EditorPanel.jsx
+++ b/src/app/components/markdownEditor/EditorPanel.jsx
@@ -10,15 +10,10 @@ import { markdownToDraft, draftToMarkdown } from "markdown-draft-js";
 import React from "react";
 import f from "lodash/fp";
 import i18n from "i18next";
-import listensToClickOutside from "react-onclickoutside";
 
 import PropTypes from "prop-types";
 
-import {
-  either,
-  preventDefault,
-  stopPropagation
-} from "../../helpers/functools";
+import { stopPropagation } from "../../helpers/functools";
 import StyleControls from "./StyleControls";
 
 const markdownToState = f.compose(
@@ -31,140 +26,44 @@ const stateToMarkdown = f.compose(
   convertToRaw
 );
 
-const LinkEditor = ({ editorState, setEditorState, handleClickOutside }) => {
-  const getUrlAtPoint = selection => {
-    if (!selection.isCollapsed()) {
-      // Adapted from DraftJS link example
-      // https://github.com/facebook/draft-js/blob/ceaeebf1f50fee452d92d71c5e2008e3d4fb6d9f/examples/draft-0-10-0/link/link.html#L76
-      const content = editorState.getCurrentContent();
-      const startKey = selection().getStartKey();
-      const startOffset = selection.getStartOffset();
-      const blockWithLinkAtBeginning = content.getBlockForKey(startKey);
-      const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
-
-      const url = linkKey ? content.getEntity(linkKey).getData().url : "";
-      return url;
-    } else {
-      return "";
-    }
-  };
-
-  const [url, setUrl] = React.useState(
-    either(editorState.getSelection())
-      .map(getUrlAtPoint)
-      .getOrElse("")
-  );
-
-  const inputRef = React.useRef();
-
-  const handleUrlChange = React.useCallback(event => {
-    setUrl(event.target.value);
-    // forceTheGoddamnFocus();
-  });
-
-  const removeLink = React.useCallback(event => {
-    preventDefault(event);
-    const selection = editorState.getSelection();
-    if (!selection.isCollapsed()) {
-      setEditorState(RichUtils.toggleLink(editorState, selection, null));
-    }
-  });
-
-  const setLinkUrl = React.useCallback(event => {
-    preventDefault(event);
-    const content = editorState.getCurrentContent();
-    const contentWithNewLink = content.createEntity("LINK", "MUTABLE", { url });
-    const entityKey = contentWithNewLink.getLastCreatedEntityKey();
-    const newEditorState = EditorState.set(editorState, {
-      currentContent: contentWithNewLink
-    });
-    setEditorState(
-      RichUtils.toggleLink(
-        newEditorState,
-        newEditorState.getSelection(),
-        entityKey
-      )
-    );
-    handleClickOutside();
-  });
-
+const Link = props => {
+  const { url } = props.contentState.getEntity(props.entityKey).getData();
   return (
-    <div
-      className="link-editor"
-      style={{ display: "flex", justifyContent: "space-between" }}
-    >
-      <button
-        className="link-editor__cancel-button button"
-        onClick={handleClickOutside}
-      >
-        {i18n.t("common:cancel")}
-      </button>
-      <input
-        placeholder={i18n.t("common:url")}
-        className="link-editor__input"
-        type="text"
-        value={url}
-        onChange={handleUrlChange}
-        ref={inputRef}
-      />
-      <button
-        className="link-editor__confirm-button button positive"
-        onClick={setLinkUrl}
-      >
-        {i18n.t("common:ok")}
-      </button>
-    </div>
+    <a className="markdown-editor__link" href={url}>
+      {props.children}
+    </a>
   );
 };
-
-LinkEditor.propTypes = {
-  handleClickOutside: PropTypes.func.isRequired,
-  setEditorState: PropTypes.func.isRequired,
-  editorState: PropTypes.object.isRequired
-};
-
-// {editLink ? (
-//     <SelfClosingLinkEditor
-//         handleClickOutside={closeLinkOverlay}
-//         editorState={editorState}
-//         setEditorState={setEditorState}
-//     />
-// ) : (
-//     <button onClick={openLinkOverlay}>open link overlay</button>
-// )}
 
 class EditorPanel extends React.PureComponent {
-  static Link = props => {
-    const { url } = props.contentState.getEntity(props.entityKey).getData();
-    return (
-      <a className="markdown-editor__link" href={url}>
-        {props.children}
-      </a>
-    );
-  };
-
-  static findLinkEntities = (contentBlock, callback, contentState) => {
-    contentBlock.findEntityRanges(character => {
-      const entityKey = character.getEntity();
-      return (
-        !f.isNil(entityKey) &&
-        contentState.getEntity(entityKey).getType() === "LINK"
-      );
-    }, callback);
-  };
-
-  static decorator = new CompositeDecorator([
-    { strategy: EditorPanel.findLinkEntities, component: EditorPanel.Link }
-  ]);
-
   constructor(props) {
     super(props);
     const { initialMarkdown } = props;
+
+    const findLinkEntities = (contentBlock, callback, contentState) => {
+      contentBlock.findEntityRanges(character => {
+        const entityKey = character.getEntity();
+        return (
+          !f.isNil(entityKey) &&
+          contentState.getEntity(entityKey).getType() === "LINK"
+        );
+      }, callback);
+    };
+
+    const decorator = new CompositeDecorator([
+      { strategy: findLinkEntities, component: Link }
+    ]);
+
+    console.log(decorator);
+
     this.state = {
       editorState: EditorState.createWithContent(
-        markdownToState(initialMarkdown, EditorPanel.decorator)
+        markdownToState(initialMarkdown),
+        decorator
       )
     };
+
+    console.log(this.state.editorState);
   }
 
   handleChange = (newState, callback) => {
@@ -189,13 +88,8 @@ class EditorPanel extends React.PureComponent {
   toggleBlockType = this.toggleStyle(RichUtils.toggleBlockType);
   toggleInlineStyle = this.toggleStyle(RichUtils.toggleInlineStyle);
 
-  keepMouseFocus = event => {
-    stopPropagation(event);
-  };
-
   focus = () => this.editorRefElement && this.editorRefElement.focus();
   editorRef = element => (this.editorRefElement = element);
-  linkEditorRef = element => (this.linkEditorRefElement = element);
 
   setEditorState = (editorState, callback) => {
     this.setState({ editorState }, state => {
@@ -207,7 +101,6 @@ class EditorPanel extends React.PureComponent {
     const { hideToolbar, readOnly, controlButtons } = this.props;
     const { editorState } = this.state;
     const {
-      keepMouseFocus,
       toggleBlockType,
       toggleInlineStyle,
       setEditorState,
@@ -216,44 +109,29 @@ class EditorPanel extends React.PureComponent {
       handleKeyCommand
     } = this;
 
-    return (
-      <>
-        <div onMouseDown={stopPropagation} onClick={stopPropagation}>
-          {!hideToolbar && (
-            <StyleControls
-              toggleBlockType={toggleBlockType}
-              toggleInlineStyle={toggleInlineStyle}
-              editorState={editorState}
-              additionalButtons={controlButtons}
-            />
-          )}
-        </div>
+    console.log(editorState.getLastChangeType());
 
-        <div
-          ref={this.linkEditorRef}
-          className="focus-keeper"
-          onClick={keepMouseFocus}
-          onMouseDown={keepMouseFocus}
-          onMouseUp={keepMouseFocus}
-        >
-          <LinkEditor
-            handleClickOutside={() => null}
+    return (
+      <div onMouseDown={stopPropagation} onClick={stopPropagation}>
+        {!hideToolbar && (
+          <StyleControls
+            toggleBlockType={toggleBlockType}
+            toggleInlineStyle={toggleInlineStyle}
             editorState={editorState}
             setEditorState={setEditorState}
+            additionalButtons={controlButtons}
           />
-        </div>
+        )}
 
-        <div onMouseDown={stopPropagation} onClick={stopPropagation}>
-          <Editor
-            readOnly={readOnly}
-            ref={editorRef}
-            editorState={editorState}
-            onChange={handleChange}
-            handleKeyCommand={handleKeyCommand}
-            placeholder={i18n.t("table:empty.text")}
-          />
-        </div>
-      </>
+        <Editor
+          readOnly={readOnly}
+          ref={editorRef}
+          editorState={editorState}
+          onChange={handleChange}
+          handleKeyCommand={handleKeyCommand}
+          placeholder={i18n.t("table:empty.text")}
+        />
+      </div>
     );
   }
 }

--- a/src/app/components/markdownEditor/EditorPanel.jsx
+++ b/src/app/components/markdownEditor/EditorPanel.jsx
@@ -1,4 +1,5 @@
 import {
+  CompositeDecorator,
   Editor,
   EditorState,
   convertFromRaw,
@@ -9,9 +10,15 @@ import { markdownToDraft, draftToMarkdown } from "markdown-draft-js";
 import React from "react";
 import f from "lodash/fp";
 import i18n from "i18next";
+import listensToClickOutside from "react-onclickoutside";
 
 import PropTypes from "prop-types";
 
+import {
+  either,
+  preventDefault,
+  stopPropagation
+} from "../../helpers/functools";
 import StyleControls from "./StyleControls";
 
 const markdownToState = f.compose(
@@ -24,73 +31,234 @@ const stateToMarkdown = f.compose(
   convertToRaw
 );
 
-const EditorPanel = (
-  { controlButtons, initialMarkdown, onChange, hideToolbar, readOnly },
-  ref
-) => {
-  const [editorState, setEditorState] = React.useState(
-    EditorState.createWithContent(markdownToState(initialMarkdown))
-  );
-  const editorRef = React.useRef();
-  React.useImperativeHandle(ref, () => ({
-    focus: editorRef.current && editorRef.current.focus()
-  }));
+const LinkEditor = ({ editorState, setEditorState, handleClickOutside }) => {
+  const getUrlAtPoint = selection => {
+    if (!selection.isCollapsed()) {
+      // Adapted from DraftJS link example
+      // https://github.com/facebook/draft-js/blob/ceaeebf1f50fee452d92d71c5e2008e3d4fb6d9f/examples/draft-0-10-0/link/link.html#L76
+      const content = editorState.getCurrentContent();
+      const startKey = selection().getStartKey();
+      const startOffset = selection.getStartOffset();
+      const blockWithLinkAtBeginning = content.getBlockForKey(startKey);
+      const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
 
-  const handleChange = React.useCallback(newState => {
-    setEditorState(newState);
-    onChange(stateToMarkdown(newState.getCurrentContent()));
-  });
-
-  const handleKeyCommand = React.useCallback((command, transientState) => {
-    const newState = RichUtils.handleKeyCommand(transientState, command);
-    if (newState) {
-      setEditorState(newState);
-      return "handled";
+      const url = linkKey ? content.getEntity(linkKey).getData().url : "";
+      return url;
+    } else {
+      return "";
     }
-    return "not-handled";
+  };
+
+  const [url, setUrl] = React.useState(
+    either(editorState.getSelection())
+      .map(getUrlAtPoint)
+      .getOrElse("")
+  );
+
+  const inputRef = React.useRef();
+
+  const handleUrlChange = React.useCallback(event => {
+    setUrl(event.target.value);
+    // forceTheGoddamnFocus();
   });
 
-  const toggleBlockType = React.useCallback(typeToToggle => {
-    const stateWithToggledBlock = RichUtils.toggleBlockType(
-      editorState,
-      typeToToggle
+  const removeLink = React.useCallback(event => {
+    preventDefault(event);
+    const selection = editorState.getSelection();
+    if (!selection.isCollapsed()) {
+      setEditorState(RichUtils.toggleLink(editorState, selection, null));
+    }
+  });
+
+  const setLinkUrl = React.useCallback(event => {
+    preventDefault(event);
+    const content = editorState.getCurrentContent();
+    const contentWithNewLink = content.createEntity("LINK", "MUTABLE", { url });
+    const entityKey = contentWithNewLink.getLastCreatedEntityKey();
+    const newEditorState = EditorState.set(editorState, {
+      currentContent: contentWithNewLink
+    });
+    setEditorState(
+      RichUtils.toggleLink(
+        newEditorState,
+        newEditorState.getSelection(),
+        entityKey
+      )
     );
-    handleChange(stateWithToggledBlock);
+    handleClickOutside();
   });
-
-  const toggleInlineStyle = React.useCallback(styleToToggle => {
-    const stateWithToggledStyle = RichUtils.toggleInlineStyle(
-      editorState,
-      styleToToggle
-    );
-    handleChange(stateWithToggledStyle);
-  });
-
-  console.log({ initialMarkdown, editorState });
 
   return (
-    <>
-      {!hideToolbar && (
-        <StyleControls
-          toggleBlockType={toggleBlockType}
-          toggleInlineStyle={toggleInlineStyle}
-          editorState={editorState}
-          additionalButtons={controlButtons}
-        />
-      )}
-      <Editor
-        readOnly={readOnly}
-        ref={editorRef}
-        editorState={editorState}
-        onChange={handleChange}
-        handleKeyCommand={handleKeyCommand}
-        placeholder={i18n.t("table:empty.text")}
+    <div
+      className="link-editor"
+      style={{ display: "flex", justifyContent: "space-between" }}
+    >
+      <button
+        className="link-editor__cancel-button button"
+        onClick={handleClickOutside}
+      >
+        {i18n.t("common:cancel")}
+      </button>
+      <input
+        placeholder={i18n.t("common:url")}
+        className="link-editor__input"
+        type="text"
+        value={url}
+        onChange={handleUrlChange}
+        ref={inputRef}
       />
-    </>
+      <button
+        className="link-editor__confirm-button button positive"
+        onClick={setLinkUrl}
+      >
+        {i18n.t("common:ok")}
+      </button>
+    </div>
   );
 };
 
-export default React.forwardRef(EditorPanel);
+LinkEditor.propTypes = {
+  handleClickOutside: PropTypes.func.isRequired,
+  setEditorState: PropTypes.func.isRequired,
+  editorState: PropTypes.object.isRequired
+};
+
+// {editLink ? (
+//     <SelfClosingLinkEditor
+//         handleClickOutside={closeLinkOverlay}
+//         editorState={editorState}
+//         setEditorState={setEditorState}
+//     />
+// ) : (
+//     <button onClick={openLinkOverlay}>open link overlay</button>
+// )}
+
+class EditorPanel extends React.PureComponent {
+  static Link = props => {
+    const { url } = props.contentState.getEntity(props.entityKey).getData();
+    return (
+      <a className="markdown-editor__link" href={url}>
+        {props.children}
+      </a>
+    );
+  };
+
+  static findLinkEntities = (contentBlock, callback, contentState) => {
+    contentBlock.findEntityRanges(character => {
+      const entityKey = character.getEntity();
+      return (
+        !f.isNil(entityKey) &&
+        contentState.getEntity(entityKey).getType() === "LINK"
+      );
+    }, callback);
+  };
+
+  static decorator = new CompositeDecorator([
+    { strategy: EditorPanel.findLinkEntities, component: EditorPanel.Link }
+  ]);
+
+  constructor(props) {
+    super(props);
+    const { initialMarkdown } = props;
+    this.state = {
+      editorState: EditorState.createWithContent(
+        markdownToState(initialMarkdown, EditorPanel.decorator)
+      )
+    };
+  }
+
+  handleChange = (newState, callback) => {
+    this.setEditorState(newState, callback);
+    this.props.onChange(stateToMarkdown(newState.getCurrentContent()));
+  };
+
+  handleKeyCommand = (command, transientState) => {
+    const newState = RichUtils.handleKeyCommand(transientState, command);
+    if (newState) {
+      this.setEditorState(newState);
+      return "handled";
+    }
+    return "not-handled";
+  };
+
+  toggleStyle = toggleFunction => styleToToggle => {
+    const newState = toggleFunction(this.state.editorState, styleToToggle);
+    this.handleChange(newState, this.focus);
+  };
+
+  toggleBlockType = this.toggleStyle(RichUtils.toggleBlockType);
+  toggleInlineStyle = this.toggleStyle(RichUtils.toggleInlineStyle);
+
+  keepMouseFocus = event => {
+    stopPropagation(event);
+  };
+
+  focus = () => this.editorRefElement && this.editorRefElement.focus();
+  editorRef = element => (this.editorRefElement = element);
+  linkEditorRef = element => (this.linkEditorRefElement = element);
+
+  setEditorState = (editorState, callback) => {
+    this.setState({ editorState }, state => {
+      callback && callback(state);
+    });
+  };
+
+  render() {
+    const { hideToolbar, readOnly, controlButtons } = this.props;
+    const { editorState } = this.state;
+    const {
+      keepMouseFocus,
+      toggleBlockType,
+      toggleInlineStyle,
+      setEditorState,
+      editorRef,
+      handleChange,
+      handleKeyCommand
+    } = this;
+
+    return (
+      <>
+        <div onMouseDown={stopPropagation} onClick={stopPropagation}>
+          {!hideToolbar && (
+            <StyleControls
+              toggleBlockType={toggleBlockType}
+              toggleInlineStyle={toggleInlineStyle}
+              editorState={editorState}
+              additionalButtons={controlButtons}
+            />
+          )}
+        </div>
+
+        <div
+          ref={this.linkEditorRef}
+          className="focus-keeper"
+          onClick={keepMouseFocus}
+          onMouseDown={keepMouseFocus}
+          onMouseUp={keepMouseFocus}
+        >
+          <LinkEditor
+            handleClickOutside={() => null}
+            editorState={editorState}
+            setEditorState={setEditorState}
+          />
+        </div>
+
+        <div onMouseDown={stopPropagation} onClick={stopPropagation}>
+          <Editor
+            readOnly={readOnly}
+            ref={editorRef}
+            editorState={editorState}
+            onChange={handleChange}
+            handleKeyCommand={handleKeyCommand}
+            placeholder={i18n.t("table:empty.text")}
+          />
+        </div>
+      </>
+    );
+  }
+}
+
+export default EditorPanel;
 
 EditorPanel.propTypes = {
   initialMarkdown: PropTypes.string,

--- a/src/app/components/markdownEditor/EditorPanel.jsx
+++ b/src/app/components/markdownEditor/EditorPanel.jsx
@@ -54,16 +54,12 @@ class EditorPanel extends React.PureComponent {
       { strategy: findLinkEntities, component: Link }
     ]);
 
-    console.log(decorator);
-
     this.state = {
       editorState: EditorState.createWithContent(
         markdownToState(initialMarkdown),
         decorator
       )
     };
-
-    console.log(this.state.editorState);
   }
 
   handleChange = (newState, callback) => {
@@ -108,8 +104,6 @@ class EditorPanel extends React.PureComponent {
       handleChange,
       handleKeyCommand
     } = this;
-
-    console.log(editorState.getLastChangeType());
 
     return (
       <div onMouseDown={stopPropagation} onClick={stopPropagation}>

--- a/src/app/components/markdownEditor/LinkEditor.jsx
+++ b/src/app/components/markdownEditor/LinkEditor.jsx
@@ -1,0 +1,128 @@
+import { EditorState, RichUtils } from "draft-js";
+import React from "react";
+import i18n from "i18next";
+import listensToClickOutsice from "react-onclickoutside";
+
+import PropTypes from "prop-types";
+
+import { StyleIcon } from "./StyleControls";
+import { either } from "../../helpers/functools";
+
+const UrlInput = listensToClickOutsice(
+  ({ setLinkUrl, editorState, handleClickOutside }) => {
+    const getUrlAtPoint = selection => {
+      if (!selection.isCollapsed()) {
+        // Adapted from DraftJS link example
+        // https://github.com/facebook/draft-js/blob/ceaeebf1f50fee452d92d71c5e2008e3d4fb6d9f/examples/draft-0-10-0/link/link.html#L76
+        const content = editorState.getCurrentContent();
+        const startKey = selection().getStartKey();
+        const startOffset = selection.getStartOffset();
+        const blockWithLinkAtBeginning = content.getBlockForKey(startKey);
+        const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
+
+        const url = linkKey ? content.getEntity(linkKey).getData().url : "";
+        return url;
+      } else {
+        return "";
+      }
+    };
+
+    const [url, setUrl] = React.useState(
+      either(editorState.getSelection())
+        .map(getUrlAtPoint)
+        .getOrElse("")
+    );
+    const handleChange = React.useCallback(event => setUrl(event.target.value));
+    const closeInput = handleClickOutside;
+    const setLinkUrlAndClose = React.useCallback(() => {
+      setLinkUrl(url);
+      closeInput();
+    });
+
+    return (
+      <div className="link-editor__input">
+        <button
+          className="link-editor__cancel-button button"
+          onClick={closeInput}
+        >
+          {i18n.t("common:cancel")}
+        </button>
+        <input
+          placeholder={i18n.t("common:url")}
+          className="link-editor__input"
+          type="text"
+          value={url}
+          onChange={handleChange}
+        />
+        <button
+          className="link-editor__confirm-button button positive"
+          onClick={setLinkUrlAndClose}
+        >
+          {i18n.t("common:ok")}
+        </button>
+      </div>
+    );
+  }
+);
+UrlInput.propTypes = {
+  editorState: PropTypes.object.isRequired,
+  setLinkUrl: PropTypes.func.isRequired,
+  handleClickOutside: PropTypes.func.isRequired
+};
+
+const LinkEditor = ({ editorState, setEditorState }) => {
+  const [showUrlInput, setShowUrlInput] = React.useState(false);
+  const toggleUrlInput = React.useCallback(() =>
+    setShowUrlInput(!showUrlInput)
+  );
+  const closeUrlInput = React.useCallback(() => setShowUrlInput(false));
+
+  const removeLink = React.useCallback(() => {
+    const selection = editorState.getSelection();
+    if (!selection.isCollapsed()) {
+      setEditorState(RichUtils.toggleLink(editorState, selection, null));
+    }
+  });
+
+  const setLinkUrl = React.useCallback(url => {
+    const content = editorState.getCurrentContent();
+    const contentWithNewLink = content.createEntity("LINK", "MUTABLE", { url });
+    const entityKey = contentWithNewLink.getLastCreatedEntityKey();
+    const newEditorState = EditorState.set(editorState, {
+      currentContent: contentWithNewLink
+    });
+    setEditorState(
+      RichUtils.toggleLink(
+        newEditorState,
+        newEditorState.getSelection(),
+        entityKey
+      )
+    );
+  });
+
+  return (
+    <div className="link-editor">
+      <StyleIcon
+        toggleStyle={toggleUrlInput}
+        className={showUrlInput ? "ignore-react-onclickoutside" : undefined}
+        styleToToggle=""
+        icon="fa-link"
+      />
+      <StyleIcon toggleStyle={removeLink} styleToToggle="" icon="fa-unlink" />
+      {showUrlInput && (
+        <UrlInput
+          editorState={editorState}
+          setLinkUrl={setLinkUrl}
+          handleClickOutside={closeUrlInput}
+        />
+      )}
+    </div>
+  );
+};
+
+export default LinkEditor;
+
+LinkEditor.propTypes = {
+  setEditorState: PropTypes.func.isRequired,
+  editorState: PropTypes.object.isRequired
+};

--- a/src/app/components/markdownEditor/StyleControls.jsx
+++ b/src/app/components/markdownEditor/StyleControls.jsx
@@ -59,7 +59,8 @@ const StyleControls = ({
   ];
   const inlineStyles = [
     { type: "BOLD", icon: "fa-bold" },
-    { type: "ITALIC", icon: "fa-italic" }
+    { type: "ITALIC", icon: "fa-italic" },
+    { type: "STRIKETHROUGH", icon: "fa-strikethrough" }
     // There is no standard markdown for underline
     // { type: "UNDERLINE", icon: "fa-underline" }
   ];

--- a/src/app/components/markdownEditor/StyleControls.jsx
+++ b/src/app/components/markdownEditor/StyleControls.jsx
@@ -1,22 +1,24 @@
 import React from "react";
-import classNames from "classnames";
 
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
 import { preventDefault } from "../../helpers/functools";
+import LinkEditor from "./LinkEditor";
 
 export const StyleIcon = ({
   toggleStyle,
   styleToToggle,
   label,
   icon,
-  active
+  active,
+  className = ""
 }) => {
   const handleClick = React.useCallback(event => {
     preventDefault(event);
     toggleStyle(styleToToggle);
   });
-  const cssClass = classNames("richtext-toggle-style-button", {
+  const cssClass = classNames(className, "richtext-toggle-style-button", {
     "style-button--active": active
   });
   return (
@@ -36,14 +38,16 @@ StyleIcon.propTypes = {
   styleToToggle: PropTypes.string.isRequired,
   active: PropTypes.bool,
   icon: PropTypes.string,
-  label: PropTypes.string
+  label: PropTypes.string,
+  className: PropTypes.string
 };
 
 const StyleControls = ({
   editorState,
   toggleBlockType,
   toggleInlineStyle,
-  additionalButtons
+  additionalButtons,
+  setEditorState
 }) => {
   const blockTypes = [
     { type: "header-one", label: "H1" },
@@ -92,6 +96,7 @@ const StyleControls = ({
           label={style.label}
         />
       ))}
+      <LinkEditor editorState={editorState} setEditorState={setEditorState} />
       {additionalButtons && (
         <>
           <div className="richtext-toggle-style__placeholder" />
@@ -108,5 +113,6 @@ StyleControls.propTypes = {
   toggleBlockType: PropTypes.func.isRequired,
   toggleInlineStyle: PropTypes.func.isRequired,
   editorState: PropTypes.object.isRequired,
-  additionalButtons: PropTypes.array
+  additionalButtons: PropTypes.array,
+  setEditorState: PropTypes.func.isRequired
 };

--- a/src/scss/markdownEditor.scss
+++ b/src/scss/markdownEditor.scss
@@ -2,6 +2,13 @@ $editor-margin: 20px;
 $block-margin: 8px;
 $block-margin-narrow: 5px;
 
+@mixin richtext-link-style {
+  color: $color-primary;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .overlay .text-editor-overlay .overlay-content {
   display: flex;
   flex-direction: column;
@@ -90,6 +97,10 @@ $block-margin-narrow: 5px;
 
   .public-DraftStyleDefault-block, p {
     margin: $block-margin 0;
+
+    a {
+      @include richtext-link-style();
+    }
   }
 
   .public-DraftStyleDefault-ul, .public-DraftStyleDefault-ol, ol, ul {
@@ -124,10 +135,7 @@ $block-margin-narrow: 5px;
   }
 
   a {
-    color: $color-primary;
-    &:hover {
-      text-decoration: underline;
-    }
+    @include richtext-link-style();
   }
 }
 


### PR DESCRIPTION
This adds buttons for `strikethrough` and a miniature UI to add and remove links to selected text.
Please note that the link UI lacks styling, and only review the technical aspects.