### PR TITLE
fix showDependency in ItemPopupMenu of EntityView

### DIFF
--- a/src/app/components/entityView/ItemPopupMenu.jsx
+++ b/src/app/components/entityView/ItemPopupMenu.jsx
@@ -247,7 +247,8 @@ class ItemPopupMenu extends Component {
             {hasMeaningfulLinks
               ? this.mkEntry(0, {
                   title: "table:show_dependency",
-                  fn: () => openShowDependency(row, langtag),
+                  fn: () =>
+                    openShowDependency({ table: cell.table, row, langtag }),
                   icon: "code-fork"
                 })
               : null}


### PR DESCRIPTION
function call had wrong parameters