### PR TITLE
Visualise edited link elements

### DIFF
--- a/src/app/components/markdownEditor/LinkEditor.jsx
+++ b/src/app/components/markdownEditor/LinkEditor.jsx
@@ -69,9 +69,12 @@ UrlInput.propTypes = {
 const LinkEditor = ({ editorState, setEditorState }) => {
   const [showUrlInput, setShowUrlInput] = React.useState(false);
 
+  // (void) -> EditorState
   const toggleFakeSelectionStyle = () =>
     RichUtils.toggleInlineStyle(editorState, "UNDERLINE");
 
+  // ((any) -> any) -> void
+  // side-effects
   const toggleFakeSelectionAnd = handler => (...args) => {
     handler(...args);
     setEditorState(toggleFakeSelectionStyle());
@@ -92,11 +95,15 @@ const LinkEditor = ({ editorState, setEditorState }) => {
     }
   });
 
-  const setLinkUrl = url => {
-    // disable fake selection before proceeding
-    console.log("Linking url:", url);
-    const content = toggleFakeSelectionStyle().getCurrentContent();
-    const contentWithNewLink = content.createEntity("LINK", "MUTABLE", { url });
+  // Update editor state with link, close link input
+  const setLinkUrl = React.useCallback(url => {
+    // Disable fake selection before proceeding. DraftJS state is
+    // immutable, so subsequent changes must be chained to avoid race
+    // conditions
+    const contentWithNewLink = toggleFakeSelectionStyle()
+      .getCurrentContent()
+      .createEntity("LINK", "MUTABLE", { url });
+
     const entityKey = contentWithNewLink.getLastCreatedEntityKey();
     const newEditorState = EditorState.set(editorState, {
       currentContent: contentWithNewLink
@@ -109,7 +116,7 @@ const LinkEditor = ({ editorState, setEditorState }) => {
       )
     );
     closeUrlInput();
-  };
+  });
 
   const handleOpenUrlInput = toggleFakeSelectionAnd(openUrlInput);
   const handleCloseUrlInput = toggleFakeSelectionAnd(closeUrlInput);

--- a/src/app/components/markdownEditor/LinkEditor.jsx
+++ b/src/app/components/markdownEditor/LinkEditor.jsx
@@ -34,6 +34,10 @@ const UrlInput = listensToClickOutsice(
     );
     const handleChange = React.useCallback(event => setUrl(event.target.value));
     const closeInput = handleClickOutside;
+    const handleKeyDown = React.useCallback(
+      event => event.key === "Enter" && setLinkUrl(url),
+      [url]
+    );
 
     return (
       <div className="link-editor__input">
@@ -49,6 +53,7 @@ const UrlInput = listensToClickOutsice(
           type="text"
           value={url}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
         />
         <button
           className="link-editor__confirm-button button positive"

--- a/src/app/components/markdownEditor/StyleControls.jsx
+++ b/src/app/components/markdownEditor/StyleControls.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import f from "lodash/fp";
 
 import PropTypes from "prop-types";
 import classNames from "classnames";
@@ -12,17 +13,19 @@ export const StyleIcon = ({
   label,
   icon,
   active,
-  className = ""
+  className = "",
+  disabled
 }) => {
   const handleClick = React.useCallback(event => {
     preventDefault(event);
     toggleStyle(styleToToggle);
   });
   const cssClass = classNames(className, "richtext-toggle-style-button", {
-    "style-button--active": active
+    "style-button--active": active,
+    "style-button--disabled": disabled
   });
   return (
-    <div className={cssClass} onClick={handleClick}>
+    <div className={cssClass} onClick={disabled ? f.noop : handleClick}>
       {label ? (
         <span style={{ fontWeight: "bold" }}>{label}</span>
       ) : icon ? (
@@ -39,7 +42,8 @@ StyleIcon.propTypes = {
   active: PropTypes.bool,
   icon: PropTypes.string,
   label: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  disabled: PropTypes.bool
 };
 
 const StyleControls = ({

--- a/src/scss/markdownEditor.scss
+++ b/src/scss/markdownEditor.scss
@@ -53,6 +53,10 @@ $block-margin-narrow: 5px;
     background-color: lighten($color-primary, 20);
     color: $color-primary-contrast-text;
   }
+
+  &.style-button--disabled {
+    background-color: lighten($color-text-medium-grey, 25);
+  }
 }
 
 .DraftEditor-root {

--- a/src/scss/markdownEditor.scss
+++ b/src/scss/markdownEditor.scss
@@ -99,6 +99,13 @@ $block-margin-narrow: 5px;
     font-size: larger;
   }
 
+  // our fake selection
+  span[style="text-decoration: underline;"] {
+    background-color: lighten($color-primary, 20);
+    color: darken($color-primary-contrast-text, 0);
+    text-decoration-color: transparent !important;
+  }
+
   .public-DraftStyleDefault-block, p {
     margin: $block-margin 0;
 


### PR DESCRIPTION
When focussing the URL-input field, we lose the visual indicator which element will be transformed to a link from the edit area. As a workaround we set the `underline` style to the currently selected fraction of text when entering the link editor, and use CSS to transform it to visually highlight the selection (and we remove the style when leaving the editor).
We can safely exploit the `underline` style this way as it has no counterpart in standard markdown, so it will get stripped by the markdown processor, should we accidently save while any text is highlighted this way.

Note that no style guidance exists yet for the visual editor anyway, so please do not review the visuals for anything but their existence.