### PR TITLE
Refactor dev mode

### DIFF
--- a/src/app/components/header/NavigationPopup.jsx
+++ b/src/app/components/header/NavigationPopup.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { ENABLE_DASHBOARD } from "../../FeatureFlags";
-import { getLogin } from "../../helpers/authenticate";
+import { getLogin, noAuthNeeded } from "../../helpers/authenticate";
 import { getUserName } from "../../helpers/userNameHelper";
 import Link from "../helperComponents/Link";
 import MainMenuEntry from "../frontendService/MainMenuEntry";
@@ -62,13 +62,18 @@ const NavigationPopup = props => {
             service={service}
           />
         ))}
-        <li className="main-navigation__entry">
-          <div className="main-navigation__entry-button" onClick={handleLogout}>
-            <i className="fa fa-power-off" />
-            {t("header:menu.logout")}
-            <div className="main-navigation-entry__username">{`(${userName})`}</div>
-          </div>
-        </li>
+        {!noAuthNeeded() && (
+          <li className="main-navigation__entry">
+            <div
+              className="main-navigation__entry-button"
+              onClick={handleLogout}
+            >
+              <i className="fa fa-power-off" />
+              {t("header:menu.logout")}
+              <div className="main-navigation-entry__username">{`(${userName})`}</div>
+            </div>
+          </li>
+        )}
       </ul>
     </div>
   );

--- a/src/app/helpers/apiHelper.js
+++ b/src/app/helpers/apiHelper.js
@@ -2,9 +2,8 @@ import f from "lodash/fp";
 import fetch from "cross-fetch";
 import request from "superagent";
 
-import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
 import { doto } from "./functools.js";
-import { getLogin } from "./authenticate";
+import { getLogin, noAuthNeeded } from "./authenticate";
 import apiUrl from "./apiUrl";
 
 const buildURL = apiRoute => apiUrl(apiRoute);
@@ -68,9 +67,7 @@ export const makeRequest = async ({
 };
 
 const calcAuthHeader = () =>
-  process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE
-    ? "disabled-for-dev-mode"
-    : "Bearer " + getLogin().token;
+  noAuthNeeded() ? "disabled-for-dev-mode" : "Bearer " + getLogin().token;
 
 const fetchRequest = ({ method, targetUrl, body, responseType }) => {
   const parseResponse = response => response[responseType.toLowerCase()]();

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -26,15 +26,9 @@ const keycloakInitOptions = { onLoad: "login-required" };
 // react-redux@7 selector
 export const authSelector = f.propOr(false, ["grudStatus", "authenticated"]);
 
-export const noAuthNeeded = f.memoize(() => {
-  const result = process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE;
-  console.log("No auth needed?", {
-    NODE_ENV: process.env.NODE_ENV,
-    NO_AUTH_IN_DEV_MODE,
-    result
-  });
-  return result;
-});
+export const noAuthNeeded = f.memoize(
+  () => process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE
+);
 
 // () => Keycloak
 // Side effects: Will login on first load and memoize the result
@@ -68,7 +62,6 @@ export const getLogin = f.memoize(
 export const withUserAuthentication = noAuthNeeded()
   ? f.identity
   : Component => props => {
-      console.log("Wrapping app with authentication");
       const keycloakRef = React.useRef(getLogin());
       const keycloak = keycloakRef.current;
       const isLoggedIn = useSelector(authSelector);

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -22,41 +22,53 @@ const keycloakSettings = {
 
 const keycloakInitOptions = { onLoad: "login-required" };
 
-// () => bool
+// (state) => bool
 // react-redux@7 selector
 export const authSelector = f.propOr(false, ["grudStatus", "authenticated"]);
 
-// () => Keycloak
-// Side effects: Will login on first load and memoize the result
-export const getLogin = f.memoize(() => {
-  const keycloak = Keycloak(keycloakSettings);
-  keycloak
-    .init(keycloakInitOptions)
-    .success(status => {
-      store.dispatch(actions.setUserAuthenticated({ status }));
-    })
-    .error(err => {
-      console.error("Error authenticating user:", err);
-      store.dispatch(actions.setUserAuthenticated({ status: false }));
-    });
-
-  keycloak.onAuthLogout = () => {
-    store.dispatch(actions.setUserAuthenticated({ status: false }));
-  };
-
-  keycloak.onTokenExpired = () => {
-    keycloak.updateToken();
-  };
-
-  return keycloak;
+export const noAuthNeeded = f.memoize(() => {
+  const result = process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE;
+  console.log("No auth needed?", {
+    NODE_ENV: process.env.NODE_ENV,
+    NO_AUTH_IN_DEV_MODE,
+    result
+  });
+  return result;
 });
 
-const ignoreAuth =
-  process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE;
+// () => Keycloak
+// Side effects: Will login on first load and memoize the result
+export const getLogin = f.memoize(
+  noAuthNeeded()
+    ? f.always({})
+    : () => {
+        const keycloak = Keycloak(keycloakSettings);
+        keycloak
+          .init(keycloakInitOptions)
+          .success(status => {
+            store.dispatch(actions.setUserAuthenticated({ status }));
+          })
+          .error(err => {
+            console.error("Error authenticating user:", err);
+            store.dispatch(actions.setUserAuthenticated({ status: false }));
+          });
 
-export const withUserAuthentication = ignoreAuth
+        keycloak.onAuthLogout = () => {
+          store.dispatch(actions.setUserAuthenticated({ status: false }));
+        };
+
+        keycloak.onTokenExpired = () => {
+          keycloak.updateToken();
+        };
+
+        return keycloak;
+      }
+);
+
+export const withUserAuthentication = noAuthNeeded()
   ? f.identity
   : Component => props => {
+      console.log("Wrapping app with authentication");
       const keycloakRef = React.useRef(getLogin());
       const keycloak = keycloakRef.current;
       const isLoggedIn = useSelector(authSelector);

--- a/src/app/helpers/userNameHelper.js
+++ b/src/app/helpers/userNameHelper.js
@@ -1,13 +1,12 @@
-import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
 import { firstValidPropOr } from "./functools";
-import { getLogin } from "./authenticate";
+import { getLogin, noAuthNeeded } from "./authenticate";
 
 export const getUserName = (onlyFirstName = false) => {
   const keycloak = getLogin();
 
   const fallbackUserName =
     process.env.NODE_ENV === "production" ? "John Doe" : "GRUDling";
-  return process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE
+  return noAuthNeeded()
     ? fallbackUserName
     : firstValidPropOr(
         fallbackUserName,


### PR DESCRIPTION
- Share one common function to disable auth for local development (based on feature flag)
- modify `getLogin()` so we don't try to call non-existing auth endpoints when auth is disabled