### PR TITLE
Use auth params in production artefact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ devAccessSettings.json
 *.iml
 .idea
 /config.json
+/.indium.json

--- a/dev-server.js
+++ b/dev-server.js
@@ -1,4 +1,5 @@
-const { createServer } = require("http");
+// const { createServer } = require("http");
+const express = require("express");
 const Path = require("path");
 const Bundler = require("parcel-bundler");
 const GRUDServer = require("./src/static/ServerConfigTool.js");
@@ -65,10 +66,12 @@ bundler.serve();
 
 // serve
 
-const server = createServer(
-  GRUDServer.configProxy(proxyHandlers, defaultHandler)
-);
+const app = express();
+const proxyHandler = GRUDServer.configProxy(proxyHandlers, defaultHandler);
 
-server.listen(config.port, config.host, () => {
+app.use("/config.json", (req, res) => res.json(config));
+app.use(proxyHandler);
+
+app.listen(config.port, config.host, () => {
   console.info(`dev proxy server operating at ${config.host}:${config.port}.`);
 });

--- a/src/app/components/dashboard/support/SupportWidget.jsx
+++ b/src/app/components/dashboard/support/SupportWidget.jsx
@@ -7,8 +7,7 @@ import PropTypes from "prop-types";
 
 import { getUserName } from "../../../helpers/userNameHelper";
 import { makeRequest } from "../../../helpers/apiHelper";
-
-const webhookUrl = process.env.webhookUrl;
+import { config } from "../../../constants/TableauxConstants";
 
 const enhance = compose(
   pure,
@@ -25,7 +24,7 @@ const enhance = compose(
     }),
     handleSubmit: ({ feedback }) => () => {
       makeRequest({
-        url: webhookUrl,
+        url: config.webhookUrl,
         method: "post",
         responseType: "text",
         data: {
@@ -50,56 +49,59 @@ const SupportWidget = ({
   handleChange,
   feedback = "",
   details: { title, phone, email }
-}) => (
-  <div className="support">
-    <div className="header">
-      <div className="heading">{i18n.t("dashboard:support.heading")}</div>
-      <div className="info-text">{i18n.t("dashboard:support.info")}</div>
-    </div>
-
-    <div className="tiles">
-      <div className="contact-info">
-        <div className="heading">
-          {i18n.t("dashboard:support.contact-infos")}
-        </div>
-        <div className="contact-data">
-          <div className="details title">{title}</div>
-          <div>
-            <a href={`tel:${phone.replace(/ /g, "")}`} className="details">
-              <i className="fa fa-phone" />
-              <span>{phone}</span>
-            </a>
-          </div>
-
-          <div>
-            <a href={`mailto:${email}`} className="details">
-              <i className="fa fa-envelope-open" />
-              <span>{email}</span>
-            </a>
-          </div>
-        </div>
+}) => {
+  const { webhookUrl } = config;
+  return (
+    <div className="support">
+      <div className="header">
+        <div className="heading">{i18n.t("dashboard:support.heading")}</div>
+        <div className="info-text">{i18n.t("dashboard:support.info")}</div>
       </div>
-      {webhookUrl && !f.isEmpty(webhookUrl) && (
-        <>
-          <div className="separator" />
 
-          <div className="feedback">
-            <div className="heading">Feedback</div>
-            <textarea
-              className="input"
-              value={feedback}
-              onChange={handleChange}
-              placeholder={i18n.t("dashboard:support.feedback-placeholder")}
-            />
-            <div className="submit-button" onClick={handleSubmit}>
-              {i18n.t("dashboard:support.submit-feedback")}
+      <div className="tiles">
+        <div className="contact-info">
+          <div className="heading">
+            {i18n.t("dashboard:support.contact-infos")}
+          </div>
+          <div className="contact-data">
+            <div className="details title">{title}</div>
+            <div>
+              <a href={`tel:${phone.replace(/ /g, "")}`} className="details">
+                <i className="fa fa-phone" />
+                <span>{phone}</span>
+              </a>
+            </div>
+
+            <div>
+              <a href={`mailto:${email}`} className="details">
+                <i className="fa fa-envelope-open" />
+                <span>{email}</span>
+              </a>
             </div>
           </div>
-        </>
-      )}
+        </div>
+        {webhookUrl && !f.isEmpty(webhookUrl) && (
+          <>
+            <div className="separator" />
+
+            <div className="feedback">
+              <div className="heading">Feedback</div>
+              <textarea
+                className="input"
+                value={feedback}
+                onChange={handleChange}
+                placeholder={i18n.t("dashboard:support.feedback-placeholder")}
+              />
+              <div className="submit-button" onClick={handleSubmit}>
+                {i18n.t("dashboard:support.submit-feedback")}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 SupportWidget.propTypes = {
   langtag: PropTypes.string.isRequired

--- a/src/app/constants/TableauxConstants.js
+++ b/src/app/constants/TableauxConstants.js
@@ -6,6 +6,7 @@ var keyMirror = require("keymirror");
  * Also, this is the order an expanded row shows the languages
  */
 let languagetags;
+let _config = {};
 
 const grudConstants = {
   Directions: keyMirror({
@@ -97,7 +98,13 @@ const grudConstants = {
     WITH_COMMENT: null,
     ROW_CONTAINS: null,
     TRANSLATOR_FILTER: null
-  })
+  }),
+
+  get config() {
+    return _config;
+  },
+
+  initConfig: config => (_config = config)
 };
 
 module.exports = grudConstants;

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -7,7 +7,7 @@ import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
 import actions from "../redux/actionCreators";
 import store from "../redux/store";
 
-const authServerUrl = process.env.authServerUrl || "http://localhost:8081/auth";
+const authServerUrl = "/auth";
 const authRealm = process.env.authRealm || "GRUD";
 
 const keycloakSettings = {

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -3,12 +3,12 @@ import Keycloak from "keycloak-js";
 import React from "react";
 import f from "lodash/fp";
 
+import { config } from "../constants/TableauxConstants";
 import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
 import actions from "../redux/actionCreators";
 import store from "../redux/store";
 
-const authServerUrl = "/auth";
-const authRealm = process.env.authRealm || "GRUD";
+const { authServerUrl, authRealm } = config;
 
 const keycloakSettings = {
   realm: authRealm,

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -8,18 +8,6 @@ import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
 import actions from "../redux/actionCreators";
 import store from "../redux/store";
 
-const { authServerUrl, authRealm } = config;
-
-const keycloakSettings = {
-  realm: authRealm,
-  url: authServerUrl,
-  resource: "grud-frontend",
-  clientId: "grud-frontend",
-  "ssl-required": "external",
-  "public-client": true,
-  "confidential-port": 0
-};
-
 const keycloakInitOptions = {
   onLoad: "login-required",
   checkLoginIframe: false
@@ -39,6 +27,16 @@ export const getLogin = f.memoize(
   noAuthNeeded()
     ? f.always({})
     : () => {
+        const keycloakSettings = {
+          realm: config.authRealm,
+          url: "/auth",
+          resource: "grud-frontend",
+          clientId: "grud-frontend",
+          "ssl-required": "external",
+          "public-client": true,
+          "confidential-port": 0
+        };
+
         const keycloak = Keycloak(keycloakSettings);
         keycloak
           .init(keycloakInitOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import "babel-polyfill";
 import "../node_modules/react-select/dist/react-select.css";
 import "./app/helpers/connectionWatcher";
+import { initConfig } from "./app/constants/TableauxConstants";
 
 import { Provider } from "react-redux";
 import React from "react";
@@ -11,9 +12,14 @@ import store from "./app/redux/store";
 
 console.log("Campudus GRUD frontend", process.env.BUILD_ID);
 
-ReactDOM.render(
-  <Provider store={store}>
-    <GRUDRouter />
-  </Provider>,
-  document.querySelector("#tableaux")
-);
+fetch("/config.json")
+  .then(response => response.json())
+  .then(initConfig)
+  .then(() => {
+    ReactDOM.render(
+      <Provider store={store}>
+        <GRUDRouter />
+      </Provider>,
+      document.querySelector("#tableaux")
+    );
+  });

--- a/src/static/ServerConfigTool.js
+++ b/src/static/ServerConfigTool.js
@@ -59,7 +59,7 @@ const stripProxyPrefixes = prefixes => proxyReq => {
   );
 };
 
-const configProxy = (routes, defaultHandler) => {
+const configProxy = (routes, defaultHandler = null) => {
   const proxy = createProxyServer();
   const prefixRegexes = routes.map(({ prefix }) => new RegExp("^" + prefix));
 

--- a/src/static/ServerConfigTool.js
+++ b/src/static/ServerConfigTool.js
@@ -13,9 +13,6 @@ const envParams = [
   "authRealm"
 ];
 
-// These config params will be passed on to the build artefact
-const appParams = ["webhookUrl", "authServerUrl", "authRealm"];
-
 const enrichConfig = config => {
   try {
     const configPrefix = "--config=";
@@ -42,14 +39,7 @@ const enrichConfig = config => {
     }
   };
 
-  const passConfigParamToApp = param => {
-    if (config[param]) {
-      process.env[param] = config[param];
-    }
-  };
-
   envParams.forEach(overrideConfigWithEnv);
-  appParams.forEach(passConfigParamToApp);
   return config;
 };
 

--- a/src/static/grud-frontend-server.js
+++ b/src/static/grud-frontend-server.js
@@ -69,6 +69,7 @@ const resourceHandler = (req, res, next) => {
 //   next();
 // });
 app.use(proxyHandler); // if api request, proxy it, else...
+app.use("/config.json", (req, res) => res.json(config)); // serve local config at runtime
 app.use(resourceHandler); // if a file was requested, try to serve it, else...
 app.use(appHandler); // serve the single page app
 


### PR DESCRIPTION
As our webapp gets compiled before delivery, we can not pass environment parameters to it when we serve it. To solve this problem, we add an endpoint to the dev- and productions servers which deliver the server's runtime config, and then `fetch` that config into the app's memory at GRUD start.