### PR TITLE
Fix empty tables list crashing GRUD

### DIFF
--- a/src/app/components/Router.jsx
+++ b/src/app/components/Router.jsx
@@ -40,7 +40,8 @@ const GRUDRouter = React.memo(() => {
     const currentTable = currentTableSelector(store.getState());
     const urlOptions = parseOptions(routeProps.location.search);
 
-    if (!currentTable || tableId !== currentTable) {
+    // only load table if we're allowed to see at least one
+    if ((!currentTable || tableId !== currentTable) && tableId) {
       batch(() => {
         switchTable(tableId);
         store.dispatch(actionCreators.cleanUp(tableId));
@@ -51,7 +52,10 @@ const GRUDRouter = React.memo(() => {
       });
     }
 
-    return renderView(ViewNames.TABLE_VIEW)(routeProps);
+    return renderView(
+      // TableView will crash when we're not allowed to see any table
+      ViewNames.TABLE_VIEW
+    )(routeProps);
   });
 
   const renderServiceView = React.useCallback(
@@ -168,7 +172,7 @@ const isValidTableId = (tableId, tables) => {
 const isNumeric = str => /^\d+$/.test(str); // regex coerces nil values
 const validateNumber = str => (isNumeric(str) ? parseInt(str) : undefined);
 
-export const switchTable = ({ tableId }) => {
+export const switchTable = ({ tableId } = {}) => {
   store.dispatch(actionCreators.setCurrentTable(tableId));
 };
 

--- a/src/app/components/tableView/TableView.jsx
+++ b/src/app/components/tableView/TableView.jsx
@@ -2,6 +2,7 @@ import { Redirect, withRouter } from "react-router-dom";
 import React, { PureComponent } from "react";
 import f from "lodash/fp";
 import i18n from "i18next";
+import { branch, renderComponent } from "recompose";
 
 import PropTypes from "prop-types";
 
@@ -305,6 +306,28 @@ class TableView extends PureComponent {
   };
 }
 
+const EmptyTableView = withRouter(({ langtag, history }) => {
+  const handleLanguageSwitch = React.useCallback(langtag =>
+    switchLanguageHandler(history, langtag)
+  );
+
+  return (
+    <>
+      <GrudHeader
+        langtag={langtag}
+        handleLanguageSwitch={handleLanguageSwitch}
+        pageTitleOrKey="pageTitle.tables"
+      />
+      <div className="initial-loader">
+        <div className="centered-user-message">
+          {i18n.t("table:no-tables-found")}
+        </div>
+      </div>
+      <Redirect to={`/${langtag}/tables`} />
+    </>
+  );
+});
+
 TableView.propTypes = {
   langtag: PropTypes.string.isRequired,
   overlayOpen: PropTypes.bool.isRequired,
@@ -312,4 +335,7 @@ TableView.propTypes = {
   projection: PropTypes.object
 };
 
-export default reduxActionHoc(TableView, mapStatetoProps);
+export default branch(
+  props => f.isNil(props.tableId),
+  renderComponent(EmptyTableView)
+)(reduxActionHoc(TableView, mapStatetoProps));

--- a/src/locales/de/table.json
+++ b/src/locales/de/table.json
@@ -129,5 +129,6 @@
   "open-link-filtered": "Öffne verknüpfte Datensätze",
   "open-dataset": "Tabelle mit diesem Datensatz öffnen",
   "redo": "Letzte Änderung wiederholen",
-  "undo": "Letzte Änderung rückgängig machen"
+  "undo": "Letzte Änderung rückgängig machen",
+  "no-tables-found": "Es existieren keine sichtbaren Tabellen"
 }

--- a/src/locales/en/table.json
+++ b/src/locales/en/table.json
@@ -129,5 +129,6 @@
   "open-link-filtered": "Open linked data",
   "open-dataset": "Open table with this dataset",
   "undo": "Undo last data change",
-  "redo": "Redo last data change"
+  "redo": "Redo last data change",
+  "no-tables-found": "There are no visible tables"
 }

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -23,6 +23,15 @@ header {
   top: 0;
   left: 0;
   position: absolute;
+
+  .centered-user-message {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: x-large;
+    color: $color-text-medium-grey;
+  }
 }
 
 .clearfix {


### PR DESCRIPTION
When there is no table the user is allowed to see, navigating to TableView would crash the GRUD. This fix will branch the TableView in this case, so the user sees an empty TableView without table controls but with default navigation and a helpful message.