### PR TITLE
Allow disabling auth via env params

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,25 @@ Go to project directory and execute:
 
     npm run clean && npm run build
 
+## Build project without user authentication
+
+Build artefact with
+
+    AUTH_REQUIRED=false npm run build
+
+then serve normally with `npm run start`.
+
 ## Overview of npm tasks
 
 ``` shell
 npm run
-  start             # create production bundle and serve at serverPort
   build             # create production bundle
+  start             # serve production bundle at serverPort
   dev               # create dev bundle and serve it at serverPort
   lint              # lint all project source files
-  lint:changes      # lint all differences to master
+  lint:changes      # lint all differences to head of master
   lint:fix          # apply automated lint fixes to all project source files
-  lint:fix:changes  # fix all changes to master
-  storybook         # start storybook
+  lint:fix:changes  # fix all differences to head of master
   test              # run tests with jest
   clean             # clean build cache and out directory
   clean:project     # clean build cache and out directory, reinstall all dependencies
@@ -72,6 +79,9 @@ Following variable names can be used:
 - REDUX_DEVTOOLS=[true,false]
 - AUTH_SERVER_URL
 - AUTH_REALM
+- AUTH_REQUIRED=[true,false] (ignored in production when not present at build time)
+
+Example:
 
 ```
 PORT=3001 npm run start

--- a/src/app/FeatureFlags.js
+++ b/src/app/FeatureFlags.js
@@ -1,5 +1,5 @@
 export const ENABLE_DASHBOARD = true;
 export const SHOW_DASHBOARD_USER_NAME = true;
 export const KEYBOARD_TABLE_HISTORY = true;
-export const AUTH_REQUIRED = true;
 export const NO_AUTH_IN_DEV_MODE = false;
+export const AUTH_REQUIRED = process.env.AUTH_REQUIRED !== "false";

--- a/src/app/FeatureFlags.js
+++ b/src/app/FeatureFlags.js
@@ -1,4 +1,5 @@
 export const ENABLE_DASHBOARD = true;
 export const SHOW_DASHBOARD_USER_NAME = true;
 export const KEYBOARD_TABLE_HISTORY = true;
+export const AUTH_REQUIRED = true;
 export const NO_AUTH_IN_DEV_MODE = false;

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import f from "lodash/fp";
 
 import { config } from "../constants/TableauxConstants";
-import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
+import { NO_AUTH_IN_DEV_MODE, AUTH_REQUIRED } from "../FeatureFlags";
 import actions from "../redux/actionCreators";
 import store from "../redux/store";
 
@@ -17,9 +17,11 @@ const keycloakInitOptions = {
 // react-redux@7 selector
 export const authSelector = f.propOr(false, ["grudStatus", "authenticated"]);
 
-export const noAuthNeeded = f.memoize(
-  () => process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE
-);
+export const noAuthNeeded = f.memoize(() => {
+  const canSafelyIgnoreAuth =
+    process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE;
+  return !AUTH_REQUIRED || canSafelyIgnoreAuth;
+});
 
 // () => Keycloak
 // Side effects: Will login on first load and memoize the result

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -29,8 +29,16 @@ export const getLogin = f.memoize(
   noAuthNeeded()
     ? f.always({})
     : () => {
+        if (f.any(f.isEmpty, [config.authRealm, config.authServerUrl])) {
+          alert(
+            "This GRUD instance is configured to use keycloak authentication, " +
+              "but authentication settings were not configured correctly.\n" +
+              "Things can and possibly will break. Proceed at your own risk."
+          );
+        }
+
         const keycloakSettings = {
-          realm: config.authRealm,
+          realm: config.authRealm || "grud",
           url: "/auth",
           resource: "grud-frontend",
           clientId: "grud-frontend",

--- a/src/app/helpers/connectionWatcher.js
+++ b/src/app/helpers/connectionWatcher.js
@@ -67,11 +67,13 @@ connectionStatus
     });
   });
 
-if (process.env.NODE_ENV === "production") {
-  connectionStatus.next({
-    connected: true,
-    time: new Moment()
-  });
-  pingDelayed(getPingDelay("assumeConnected"));
-  console.log(`Keepalive ping every ~${AVG_PING_DELAY}s`);
-}
+export const watchServerConnection = () => {
+  if (process.env.NODE_ENV === "production") {
+    connectionStatus.next({
+      connected: true,
+      time: new Moment()
+    });
+    pingDelayed(getPingDelay("assumeConnected"));
+    console.log(`Keepalive ping every ~${AVG_PING_DELAY}s`);
+  }
+};

--- a/src/app/initGrud.js
+++ b/src/app/initGrud.js
@@ -10,6 +10,7 @@ import { getUserName } from "./helpers/userNameHelper";
 import { initDevelopmentAccessCookies } from "./helpers/accessManagementHelper";
 import { makeRequest } from "./helpers/apiHelper";
 import { promisifyAction } from "./redux/redux-helpers";
+import { watchServerConnection } from "./helpers/connectionWatcher";
 import TableauxConstants from "./constants/TableauxConstants";
 import actions from "./redux/actionCreators";
 import route from "./helpers/apiRoutes";
@@ -33,6 +34,8 @@ export const initGrud = async setSuccess => {
       loadTables,
       maybeInitSentry
     ]);
+
+    watchServerConnection();
     setSuccess(true);
     return true;
   } catch (err) {


### PR DESCRIPTION
- await authentication before pinging server status (else strange things may happen)
- add env var `AUTH_REQUIRED=[true,false]` for `dev` and `build` tasks (ignored at `start` task!)
- warn for missing auth config params when auth is enabled