### PR TITLE
Make identifier column resizable

### DIFF
--- a/src/app/components/columns/ColumnEntry.jsx
+++ b/src/app/components/columns/ColumnEntry.jsx
@@ -194,7 +194,7 @@ export default class ColumnEntry extends React.PureComponent {
           bottomLeft: false,
           bottomRight: false,
           left: false,
-          right: this.props.index !== 1,
+          right: true,
           top: false,
           topLeft: false,
           topRight: false

--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -123,6 +123,9 @@ export default class VirtualTable extends PureComponent {
     maybe(this.multiGrid)
       .method("recomputeGridSize")
       .method("invalidateCellSizeAfterRender");
+    if (index === 1) {
+      this.multiGrid.forceUpdate();
+    }
   };
 
   setOpenAnnotations = cell => {


### PR DESCRIPTION
Unfortunately, we have to use forceUpdate on the Grid, as fixed columns
don't update on resize.