### PR TITLE
Prevent row concat helper crashing on array columns

### DIFF
--- a/src/app/helpers/RowConcatHelper.js
+++ b/src/app/helpers/RowConcatHelper.js
@@ -3,17 +3,25 @@ import f from "lodash/fp";
 
 import PropTypes from "prop-types";
 
+import { ifElse } from "./functools";
 import { retrieveTranslation } from "./multiLanguage";
 import Empty from "../components/helperComponents/emptyEntry";
 import getDisplayValue from "./getDisplayValue";
 
 const rowConcatString = (idColumn, row, langtag) => {
   const firstCellValue = f.get(["values", 0], row);
-
-  return retrieveTranslation(
-    langtag,
-    getDisplayValue(idColumn, firstCellValue)
+  const translate = retrieveTranslation(langtag);
+  // links/attachments in primary column create arrays, thus failing retrieveTranslation spec
+  const translateArray = f.compose(
+    f.join(", "),
+    f.map(translate)
   );
+  const applyTranslation = ifElse(f.isArray, translateArray, translate);
+
+  return f.compose(
+    applyTranslation,
+    getDisplayValue(idColumn)
+  )(firstCellValue);
 };
 
 const RowConcat = props => {


### PR DESCRIPTION
If the only id column of a table is of array type, like links or
attachments, trying to retrieve a proper translation would crash the
GRUD as arrays don't match the data type expected by the translation
helper.