### PR TITLE
Replace some leftover manual translations with helper

### DIFF
--- a/src/app/components/cells/text/TextCell.jsx
+++ b/src/app/components/cells/text/TextCell.jsx
@@ -1,13 +1,13 @@
-import React from "react";
-import TextEditOverlay from "./TextEditOverlay";
-import ExpandButton from "./ExpandButton.jsx";
-import f from "lodash/fp";
-import { FallbackLanguage } from "../../../constants/TableauxConstants";
-import Header from "../../overlay/Header";
-import { doto } from "../../../helpers/functools";
-
 import "../../../../scss/main.scss";
+
 import { withHandlers } from "recompose";
+import React from "react";
+import f from "lodash/fp";
+
+import { getTableDisplayName } from "../../../helpers/multiLanguage";
+import ExpandButton from "./ExpandButton.jsx";
+import Header from "../../overlay/Header";
+import TextEditOverlay from "./TextEditOverlay";
 
 const TextCell = props => {
   const { langtag, displayValue, selected, openEditOverlay } = props;
@@ -34,16 +34,7 @@ const enhance = withHandlers({
     if (selected) {
       event && event.stopPropagation();
 
-      const context = doto(
-        [
-          table.displayName[langtag],
-          table.displayName[FallbackLanguage],
-          table.name
-        ],
-        f.compact,
-        f.first,
-        ctx => (f.isString(ctx) ? ctx : f.toString(ctx))
-      );
+      const context = getTableDisplayName(table, langtag);
 
       actions.openOverlay({
         head: <Header context={context} langtag={langtag} />,

--- a/src/app/components/header/ColumnFilterPopup.jsx
+++ b/src/app/components/header/ColumnFilterPopup.jsx
@@ -1,18 +1,17 @@
+import { List } from "react-virtualized";
 import React from "react";
-import listensToClickOutside from "react-onclickoutside";
 import * as f from "lodash/fp";
 import i18n from "i18next";
-import { either } from "../../helpers/functools";
-import { List } from "react-virtualized";
-import {
-  Directions,
-  FallbackLanguage,
-  FilterModes
-} from "../../constants/TableauxConstants";
-import SearchFunctions from "../../helpers/searchFunctions";
-import KeyboardShortcutsHelper from "../../helpers/KeyboardShortcutsHelper";
-import classNames from "classnames";
+import listensToClickOutside from "react-onclickoutside";
+
 import PropTypes from "prop-types";
+import classNames from "classnames";
+
+import { Directions, FilterModes } from "../../constants/TableauxConstants";
+import { either } from "../../helpers/functools";
+import { getColumnDisplayName } from "../../helpers/multiLanguage";
+import KeyboardShortcutsHelper from "../../helpers/KeyboardShortcutsHelper";
+import SearchFunctions from "../../helpers/searchFunctions";
 
 @listensToClickOutside
 class ColumnFilterPopup extends React.Component {
@@ -98,9 +97,7 @@ class ColumnFilterPopup extends React.Component {
 
   getColName = col =>
     either(col)
-      .map(f.prop(["displayName", this.props.langtag]))
-      .orElse(f.prop(["displayName", FallbackLanguage]))
-      .orElse(f.prop(["name"]))
+      .map(_column => getColumnDisplayName(_column, this.props.langtag))
       .getOrElseThrow("Could not extract displayName or name from  " + col);
 
   renderCheckboxItems = columns => ({ key, index, style }) => {

--- a/src/app/components/header/tableSettings/NameEditor.jsx
+++ b/src/app/components/header/tableSettings/NameEditor.jsx
@@ -5,11 +5,12 @@
  * Aborts input on "Escape" key.
  */
 import React, { PureComponent } from "react";
-import i18n from "i18next";
-import TableauxConstants from "../../../constants/TableauxConstants";
 import * as f from "lodash/fp";
-// import ActionCreator from "../../../actions/ActionCreator";
+import i18n from "i18next";
+
 import PropTypes from "prop-types";
+
+import { getTableDisplayName } from "../../../helpers/multiLanguage";
 
 class NameEditor extends PureComponent {
   constructor(props) {
@@ -27,7 +28,7 @@ class NameEditor extends PureComponent {
   startEditing = evt => {
     this.setState({
       active: true,
-      name: this.getTableDisplayName()
+      name: getTableDisplayName(this.props.table, this.props.langtag)
     });
     evt.stopPropagation();
   };
@@ -44,18 +45,6 @@ class NameEditor extends PureComponent {
 
   saveAndClose = function() {}; // composed by constructor
 
-  getTableDisplayName = () => {
-    const {
-      table: { displayName, name },
-      langtag
-    } = this.props;
-    return (
-      displayName[langtag] ||
-      displayName[TableauxConstants.FallbackLanguage] ||
-      name
-    );
-  };
-
   handleTextChange = evt => {
     if (evt && evt.target) {
       this.setState({ name: evt.target.value });
@@ -68,11 +57,12 @@ class NameEditor extends PureComponent {
 
   saveTableName = () => {
     const { name } = this.state;
-    if (this.getTableDisplayName() === name) {
+    const { table, langtag, changeTableName } = this.props;
+
+    if (getTableDisplayName(table, langtag) === name) {
       return;
     } // guardian
 
-    const { table, langtag, changeTableName } = this.props;
     const patchObj = { displayName: { [langtag]: name } };
     changeTableName(table.id, patchObj);
   };

--- a/src/app/components/header/tableSwitcher/TableSwitcher.jsx
+++ b/src/app/components/header/tableSwitcher/TableSwitcher.jsx
@@ -1,11 +1,14 @@
+import { translate } from "react-i18next";
 import React from "react";
 import f from "lodash/fp";
-import TableauxConstants from "../../../constants/TableauxConstants";
-import TableSwitcherPopup from "./TableSwitcherPopup";
-import { translate } from "react-i18next";
-import * as AccessControl from "../../../helpers/accessManagementHelper";
-import classNames from "classnames";
+
 import PropTypes from "prop-types";
+import classNames from "classnames";
+
+import { getTableDisplayName } from "../../../helpers/multiLanguage";
+import * as AccessControl from "../../../helpers/accessManagementHelper";
+import TableSwitcherPopup from "./TableSwitcherPopup";
+import TableauxConstants from "../../../constants/TableauxConstants";
 
 @translate(["header"])
 class TableSwitcherButton extends React.PureComponent {
@@ -65,12 +68,7 @@ class TableSwitcherButton extends React.PureComponent {
     );
 
     const getDisplayName = f.pipe(
-      f.props([
-        ["displayName", langtag],
-        ["displayName", TableauxConstants.FallbackLanguage],
-        ["name"]
-      ]),
-      f.find(f.identity), // first non-nil
+      table => getTableDisplayName(table, langtag),
       f.deburr,
       f.toLower
     );
@@ -105,9 +103,7 @@ class TableSwitcherButton extends React.PureComponent {
 
     // Show display name with fallback to machine name
     const table = this.props.currentTable;
-    const tableDisplayName =
-      table.displayName[this.props.langtag] ||
-      (table.displayName[TableauxConstants.FallbackLanguage] || table.name);
+    const tableDisplayName = getTableDisplayName(table, this.props.langtag);
     const cssClass = classNames("", {
       active: this.state.isOpen,
       "admin-mode": AccessControl.isUserAdmin()

--- a/src/app/components/header/tableSwitcher/TableSwitcherPopup.jsx
+++ b/src/app/components/header/tableSwitcher/TableSwitcherPopup.jsx
@@ -5,11 +5,12 @@ import listensToClickOutside from "react-onclickoutside";
 
 import PropTypes from "prop-types";
 
-import {
-  FallbackLanguage,
-  FilterModes
-} from "../../../constants/TableauxConstants";
+import { FilterModes } from "../../../constants/TableauxConstants";
 import { forkJoin, maybe } from "../../../helpers/functools";
+import {
+  getTableDisplayName,
+  retrieveTranslation
+} from "../../../helpers/multiLanguage";
 import KeyboardShortcutsHelper from "../../../helpers/KeyboardShortcutsHelper";
 import SearchFunctions from "../../../helpers/searchFunctions";
 import TableauxRouter from "../../../router/router";
@@ -185,14 +186,8 @@ class SwitcherPopup extends React.PureComponent {
 
   getFilteredTables = (filterGroupId, filterTableName) => {
     const { langtag, tables } = this.props;
-    const getDisplayNameOrFallback = f.flow(
-      f.props([
-        ["displayName", langtag],
-        ["displayName", FallbackLanguage],
-        " "
-      ]),
-      f.find(f.identity)
-    );
+    const getDisplayNameOrFallback = table =>
+      getTableDisplayName(table, langtag);
     const matchesQuery = query =>
       f.flow(
         forkJoin(
@@ -220,8 +215,7 @@ class SwitcherPopup extends React.PureComponent {
     const { t, langtag } = this.props;
 
     const renderGroup = group => {
-      const groupDisplayName =
-        group.displayName[langtag] || group.displayName[FallbackLanguage];
+      const groupDisplayName = retrieveTranslation(langtag, group);
 
       const isNoGroupGroup = group.id === 0;
       const isActive = this.state.filterGroupId === group.id;
@@ -283,10 +277,7 @@ class SwitcherPopup extends React.PureComponent {
     const hasResults = hasGroupResults || hasOtherResults;
 
     const renderTable = (table, index) => {
-      const displayName =
-        table.displayName[langtag] ||
-        table.displayName[FallbackLanguage] ||
-        table.name;
+      const displayName = getTableDisplayName(table, langtag);
       const tableId = table.id;
       const isActive = f.every(f.identity, [
         f.matchesProperty("id", focusTableId)(table),
@@ -326,11 +317,7 @@ class SwitcherPopup extends React.PureComponent {
               query: this.state.filterTableName,
               group: f.flow(
                 f.find(f.matchesProperty("id", groupId)),
-                f.props([
-                  ["displayName", langtag],
-                  ["displayName", FallbackLanguage]
-                ]),
-                f.find(f.identity)
+                retrieveTranslation(langtag)
               )(groups)
             })}
           </div>

--- a/src/app/components/overlay/EntityView/columnFilter.js
+++ b/src/app/components/overlay/EntityView/columnFilter.js
@@ -1,7 +1,4 @@
-import {
-  ColumnKinds,
-  FallbackLanguage
-} from "../../../constants/TableauxConstants";
+import { ColumnKinds } from "../../../constants/TableauxConstants";
 import SearchFunctions from "../../../helpers/searchFunctions";
 import * as f from "lodash/fp";
 import { retrieveTranslation } from "../../../helpers/multiLanguage";
@@ -23,8 +20,7 @@ const joinAttachmentFileNames = langtag =>
     f.map(
       v =>
         f.prop(["title", langtag], v) ||
-        f.prop(["externalName", langtag], v) ||
-        f.prop(["externalName", FallbackLanguage], v)
+        retrieveTranslation(langtag, v.externalName)
     ),
     f.trim,
     f.defaultTo("")


### PR DESCRIPTION
One of them caused overlay contexts to crash in some occasions,
e. g. on text edit overlays of newly duplicated rows.