### PR TITLE
[Deployment] Add some buildtime feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Default project configuration can be overwritten via a `config.json` in the base
   "outDir": "out",        // build artefacts go here
   "host": "localhost",    // host of the http frontend
   "port": 3000,           // port for the http frontent
-  "apiHost": "localhost", // 
+  "apiHost": "localhost", //
   "apiPort": 8080,        // port of the backend service
   "webhookUrl": ".."      // url for Slack webhook to recieve user feedback
 }
@@ -67,7 +67,9 @@ Following variable names can be used:
 - APIPORT
 - OUTDIR
 - WEBHOOKURL
-- REDUX_DEVTOOLS=[true,false]
+- REDUX_DEVTOOLS=[true,false] # "false" disable dev tools integration for dev performance. Default: true
+- ENABLE_HISTORY=[true,false] # Show or hide cell history button in cotext menu. Default: true
+- SHOW_TABLE_DROPDOWN=[true,false] # Show confusing table settings dropdown. Default: true
 
 ```
 PORT=3001 npm run start

--- a/src/app/FeatureFlags.js
+++ b/src/app/FeatureFlags.js
@@ -1,3 +1,11 @@
 export const ENABLE_DASHBOARD = true;
 export const SHOW_DASHBOARD_USER_NAME = false;
 export const KEYBOARD_TABLE_HISTORY = true;
+export const ENABLE_HISTORY = process.env.ENABLE_HISTORY !== "false";
+export const SHOW_TABLE_DROPDOWN = process.env.SHOW_TABLE_DROPDOWN !== "false";
+
+console.log(
+  "Environment:",
+  process.env.ENABLE_HISTORY,
+  process.env.SHOW_TABLE_DROPDOWN
+);

--- a/src/app/components/contextMenu/RowContextMenu.jsx
+++ b/src/app/components/contextMenu/RowContextMenu.jsx
@@ -7,6 +7,7 @@ import withClickOutside from "react-onclickoutside";
 import PropTypes from "prop-types";
 
 import { ColumnKinds, Langtags } from "../../constants/TableauxConstants";
+import { ENABLE_HISTORY } from "../../FeatureFlags";
 import {
   addTranslationNeeded,
   deleteCellAnnotation,
@@ -325,7 +326,8 @@ class RowContextMenu extends React.Component {
               "commenting-o"
             )
           : null}
-        {!f.contains(this.props.cell.kind, [
+        {ENABLE_HISTORY &&
+        !f.contains(this.props.cell.kind, [
           ColumnKinds.group,
           ColumnKinds.concat
         ])

--- a/src/app/components/header/tableSettings/TableSettings.jsx
+++ b/src/app/components/header/tableSettings/TableSettings.jsx
@@ -1,8 +1,11 @@
 /** Displays a cogwheel icon that, when clicked, displays an instance of TableSettingsPopup */
-import React from "react";
-import TableSettingsPopup from "./TableSettingsPopup";
 import { contains } from "lodash/fp";
+import React from "react";
+
 import PropTypes from "prop-types";
+
+import { SHOW_TABLE_DROPDOWN } from "../../../FeatureFlags";
+import TableSettingsPopup from "./TableSettingsPopup";
 
 class TableSettings extends React.Component {
   constructor(props) {
@@ -29,26 +32,28 @@ class TableSettings extends React.Component {
   render = () => {
     const { open } = this.state;
     return (
-      <div id="table-settings-wrapper" onClick={this.toggleSettingsPopup}>
-        <a
-          id="table-settings"
-          className={open ? "button active" : "button"}
-          ref={tableSettings => {
-            this.tableSettings = tableSettings;
-          }}
-          href="#"
-        >
-          <i className={open ? "fa fa-angle-up" : "fa fa-angle-down"} />
-        </a>
-        {open ? (
-          <TableSettingsPopup
-            table={this.props.table}
-            langtag={this.props.langtag}
-            outsideClickHandler={this.onClickOutside}
-            actions={this.props.actions}
-          />
-        ) : null}
-      </div>
+      SHOW_TABLE_DROPDOWN && (
+        <div id="table-settings-wrapper" onClick={this.toggleSettingsPopup}>
+          <a
+            id="table-settings"
+            className={open ? "button active" : "button"}
+            ref={tableSettings => {
+              this.tableSettings = tableSettings;
+            }}
+            href="#"
+          >
+            <i className={open ? "fa fa-angle-up" : "fa fa-angle-down"} />
+          </a>
+          {open ? (
+            <TableSettingsPopup
+              table={this.props.table}
+              langtag={this.props.langtag}
+              outsideClickHandler={this.onClickOutside}
+              actions={this.props.actions}
+            />
+          ) : null}
+        </div>
+      )
     );
   };
 }

--- a/src/scss/filter.scss
+++ b/src/scss/filter.scss
@@ -3,8 +3,8 @@
 #filter-wrapper {
   display: inline-block;
 
-  margin-top: 10px;
-  margin-right: 20px;
+  margin: 10px 20px;
+  margin-bottom: 0;
 
   outline-style: none;
 

--- a/src/scss/tableSettings.scss
+++ b/src/scss/tableSettings.scss
@@ -21,7 +21,6 @@
   display: inline-block;
 
   margin-top: 10px;
-  margin-right: 20px;
 
   .button {
     @include header-button-look();


### PR DESCRIPTION
This adds `ENABLE_HISTORY` and `SHOW_TABLE_DROPDOWN` feature flag. For deployment, they need to be present as environment values at buildtime. Both default to `true`.
Disable respective features by setting them to `false`. Check is string comparison to `"false"`.

This is just a q&d implementation, as a much more sophisticated solution exists in the `feature/auth` branch.