### PR TITLE
Allow typing just minus sign in numbers

### DIFF
--- a/src/app/components/helperComponents/NumberInput.jsx
+++ b/src/app/components/helperComponents/NumberInput.jsx
@@ -75,12 +75,18 @@ const NumberInput = (props, ref) => {
     )(inputValue);
 
     onChange(readNumericString(inputValue));
-    const stateValue = f.contains(formattedInput, ["", "0", "NaN"])
-      ? ""
-      : localize
-      ? formattedInput
-      : inputValue;
-    setValue(stateValue);
+
+    const calculateDisplayedString = () => {
+      // special case: started typing negative number
+      if (inputValue === "-") return inputValue;
+      // safety hatch for badly parsed input
+      else if (f.contains(formattedInput, ["", "0", "NaN"])) return "";
+      // localise if neccessary
+      else if (localize) return formattedInput;
+      else return inputValue;
+    };
+
+    setValue(calculateDisplayedString());
   };
 
   const inputRef = useRef();


### PR DESCRIPTION
When selecting an empty numeric cell, deleting the auto-generated zero, and then typing a minus sign as first character, the number input would automatically normalise this non-numeric input to an empty input.
This patch allows a numeric field with only a minus sign in it while typing, while still avoiding multiple minus signs and delivering a normal numeric value to its outside callbacks.