### PR TITLE
Fix initial visible Columns

### DIFF
--- a/src/app/redux/actionCreators.js
+++ b/src/app/redux/actionCreators.js
@@ -375,7 +375,9 @@ const loadCompleteTable = (tableId, urlFilters) => async dispatch => {
       dispatch(setFiltersAndSorting(filters, { sortColumnId, sortValue }));
     }
   }
-  dispatch(setColumnsVisible(visibleColumns));
+  if (!f.isEmpty(visibleColumns)) {
+    dispatch(setColumnsVisible(visibleColumns));
+  }
 };
 
 const setCurrentLanguage = lang => {


### PR DESCRIPTION
We didn't check if the visible Columns from local storage exist or are
empty, so sometimes we set visibleColumns to undefined