### PR TITLE
Fix table switcher popup error

### DIFF
--- a/src/app/components/header/tableSwitcher/TableSwitcher.jsx
+++ b/src/app/components/header/tableSwitcher/TableSwitcher.jsx
@@ -79,7 +79,7 @@ class TableSwitcherButton extends React.PureComponent {
         groups={[noGroup, ...sortedGroups]}
         tables={sortedTables}
         currentTable={currentTable}
-        onClickedOutside={this.onClickedOutside}
+        handleClickOutside={this.onClickedOutside}
         onClickedGroup={this.onClickedGroup}
         currentGroupId={this.state.currentGroupId}
         navigate={navigate}

--- a/src/app/components/header/tableSwitcher/TableSwitcherPopup.jsx
+++ b/src/app/components/header/tableSwitcher/TableSwitcherPopup.jsx
@@ -53,7 +53,7 @@ class SwitcherPopup extends React.PureComponent {
   };
 
   handleClickOutside = event => {
-    this.props.onClickedOutside(event);
+    this.props.handleClickOutside(event);
   };
 
   onClickGroup = group => () => {
@@ -395,7 +395,7 @@ class SwitcherPopup extends React.PureComponent {
 }
 
 SwitcherPopup.propTypes = {
-  onClickedOutside: PropTypes.func.isRequired,
+  handleClickOutside: PropTypes.func.isRequired,
   langtag: PropTypes.string.isRequired,
   tables: PropTypes.array.isRequired,
   groups: PropTypes.array.isRequired,


### PR DESCRIPTION
Rename prop so it will be found and used by the `react-onclickoutside`
decorator, too.