### PR TITLE
Build hang

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.storybook
+.cache
+.idea

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ node_modules
 .storybook
 .cache
 .idea
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ devAccessSettings.json
 *.iml
 .idea
 /config.json
-.npm_cache

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ devAccessSettings.json
 *.iml
 .idea
 /config.json
+.npm_cache

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
 progress=false
+cache=.npm_cache

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 save-exact=true
 progress=false
-cache=.npm_cache

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-npm_config_save_exact=true
+save-exact=true
+progress=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/app
 
 COPY package* ./
 
-RUN npm ci
+RUN npm ci --verbose
 
 COPY getCommitHash.sh .
 COPY .babelrc .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,12 @@ RUN apk update && apk upgrade && \
 
 WORKDIR /usr/app
 
-COPY .npmrc ./
-COPY package* ./
+COPY .npmrc package* ./
+COPY .npm_cache/ ./
 
-RUN npm config ls -l
-RUN npm ci -ddd
+RUN npm ci -d
 
-COPY getCommitHash.sh .
-COPY .babelrc .
+COPY getCommitHash.sh .babelrc ./
 COPY .git .git
 COPY src src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,18 @@ RUN apk update && apk upgrade && \
 
 WORKDIR /usr/app
 
-COPY .npmrc package* ./
-COPY .npm_cache/ ./
+COPY .npmrc ./
+COPY package* ./
 
 RUN npm ci -d
 
-COPY getCommitHash.sh .babelrc ./
-COPY .git .git
+COPY .babelrc .
 COPY src src
 
+ARG BUILD_ID=unknown
+ENV BUILD_ID=${BUILD_ID}
+
+RUN echo "Build with BUILD_ID: $BUILD_ID"
 RUN npm run build
 RUN npm prune --production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update && apk upgrade && \
 
 WORKDIR /usr/app
 
+COPY .npmrc ./
 COPY package* ./
 
 RUN npm config ls -l

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /usr/app
 
 COPY package* ./
 
-RUN npm ci --verbose
+RUN npm config ls -l
+RUN npm ci -ddd
 
 COPY getCommitHash.sh .
 COPY .babelrc .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
   options {
     timestamps()
     buildDiscarder(logRotator(numToKeepStr: '10'))
+    timeout(time: 15, unit: 'MINUTES')
   }
 
   stages {
@@ -78,7 +79,7 @@ pipeline {
       wrap([$class: 'BuildUser']) {
         script {
           sh "echo successful"
-          slackSend(slackParams("Build successful: ${env.JOB_NAME} @ ${env.BUILD_NUMBER} (${BUILD_USER})", "good"))
+          //slackSend(slackParams("Build successful: ${env.JOB_NAME} @ ${env.BUILD_NUMBER} (${BUILD_USER})", "good"))
         }
       }
     }
@@ -87,7 +88,7 @@ pipeline {
       wrap([$class: 'BuildUser']) {
         script {
           sh "echo failed"
-          slackSend(slackParams("Build failed: ${env.JOB_NAME} @ ${env.BUILD_NUMBER} (${BUILD_USER})", "danger"))
+          //slackSend(slackParams("Build failed: ${env.JOB_NAME} @ ${env.BUILD_NUMBER} (${BUILD_USER})", "danger"))
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,10 @@ pipeline {
     stage('Init Build') {
       steps {
         sh "mkdir -p ${DEPLOY_DIR}"
+        sh "mkdir -p .npm_cache"
+
+        // Remove frequently changed files from cache, so docker cache can be used
+        sh "rm -fR .npm_cache/_logs .npm_cache/*.json"
 
         // cleanup docker
         sh 'docker rmi $(docker images -f "dangling=true" -q) || true'
@@ -48,6 +52,7 @@ pipeline {
             * because Jenkins runs the docker container automatically within the WORKSPACE directory.
             */
             sh "cd /usr/app && ls -la && tar -czf ${WORKSPACE}/${DEPLOY_DIR}/${ARCHIVE_FILENAME_DIST} node_modules out package.json"
+            sh "cd /usr/app && cp -R .npm_cache ${WORKSPACE}"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "export NODE_ENV=production; export BUILD_ID=$(./getCommitHash.sh); node out/grud-frontend-server.js",
-    "build": "export NODE_ENV=production; export BUILD_ID=$(./getCommitHash.sh); parcel build src/index.html src/worker.js --out-dir out",
+    "build": "export NODE_ENV=production; parcel build src/index.html src/worker.js --out-dir out",
     "dev": "export NODE_ENV=development; export BUILD_ID=$(./getCommitHash.sh); node dev-server.js",
     "lint": "eslint -f stylish --ignore-pattern src/scss/FontAwesome \"src/**/*.{js,jsx}\"",
     "lint:changes": "git diff master --name-only | grep -E \"src\\/.*\\.jsx?$\" | xargs -I{} sh -c \"test -f '{}' && echo '{}'\" | xargs eslint",


### PR DESCRIPTION
Hängende builds nicht gelöst, aber mehr verboses logging eingebaut und timeout.

Außerdem wird nun die BUILD_ID per arg in den docker build übergeben, dann muss nicht der ganze .git Ordner mit kopiert werden.