### PR TITLE
Fix crash on Table-switch

### DIFF
--- a/src/app/redux/reducers/tableView.js
+++ b/src/app/redux/reducers/tableView.js
@@ -427,6 +427,7 @@ export default (state = initialState, action, completeState) => {
         ...state,
         filters: [],
         sorting: [],
+        columnOrdering: [],
         displayValues: {},
         history: [],
         expandedRowIds: []


### PR DESCRIPTION
Forgot to clean up the columnOrdering on table switch,
leading missing columns or fatal crashes in getCell.