### PR TITLE
Fix delay when an Overlay gets removed.

### DIFF
--- a/src/app/components/overlay/Overlays.jsx
+++ b/src/app/components/overlay/Overlays.jsx
@@ -20,7 +20,10 @@ const OverlayRenderer = ({
       return null;
     }
 
-    const exitingOverlays = overlays.filter(f.propEq("exiting", true));
+    const exitingOverlays = f.compose(
+      f.map("id"),
+      f.filter(f.propEq("exiting", true))
+    )(overlays);
     const bigOverlayIdces = overlays
       .map((ol, idx) => (ol.type === "full-height" ? idx : null))
       .filter(f.isInteger); // 0 is falsy


### PR DESCRIPTION
Because of an error in the Overlays-component, exitingOverlays didn't
have the right structure, leading to the removal animation never
playing.