### PR TITLE
Stop currency history from crashing GRUD

### DIFF
--- a/src/app/components/cells/currency/currencyHelper.js
+++ b/src/app/components/cells/currency/currencyHelper.js
@@ -6,7 +6,7 @@ export function getCurrencyWithCountry(
   country,
   withFallback = false
 ) {
-  const result = currencyObj[country] || null;
+  const result = f.getOr(null, country, currencyObj);
   const fallBack = getFallbackCurrencyValue({ country }, currencyObj) || null;
   return withFallback ? result || fallBack : result;
 }
@@ -16,6 +16,8 @@ export function splitPriceDecimals(priceValue) {
     return ["0", "00"];
   }
   let priceValueAsArray = String(priceValue).split(".");
-  priceValueAsArray.length === 1 ? priceValueAsArray.push("00") : null;
-  return priceValueAsArray;
+
+  return priceValueAsArray.length === 1
+    ? [...priceValueAsArray, "00"]
+    : priceValueAsArray;
 }

--- a/src/app/components/history/differ.js
+++ b/src/app/components/history/differ.js
@@ -114,19 +114,25 @@ const showCompleteReplacement = ({ displayValue, prevDisplayValue }, langtag) =>
 const calcCountryDiff = ({ fullValue, prevContent }) => {
   const countries = f.union(f.keys(fullValue), f.keys(prevContent));
   return f.flow(
-    f.flatMap(ctry => {
-      const valueFrom = f.propOr({}, ctry);
+    f.flatMap(country => {
+      const valueFrom = f.propOr({}, country);
+
       const oldVal = valueFrom(prevContent);
       const newVal = valueFrom(fullValue);
-      return oldVal === newVal // We display a minimal subset of changes for country specific items
-        ? null
-        : f.isNumber(oldVal) || !f.isEmpty(oldVal) // Number is empty. Don't ask me why
+
+      if (oldVal === newVal) {
+        // hide all changes except for the "current value" duplicate
+        return f.equals(fullValue, prevContent)
+          ? { value: oldVal, country }
+          : null;
+      }
+      return f.isNumber(oldVal) || !f.isEmpty(oldVal) // Number is empty. Don't ask me why
         ? // We can do this because of flatMap
           [
-            { del: true, value: oldVal, country: ctry },
-            { add: true, value: newVal, country: ctry }
+            { del: true, value: oldVal, country },
+            { add: true, value: newVal, country }
           ]
-        : { add: true, value: newVal, country: ctry };
+        : { add: true, value: newVal, country };
     }),
     f.compact
   )(countries);

--- a/src/scss/history/history.scss
+++ b/src/scss/history/history.scss
@@ -132,6 +132,14 @@
   }
 }
 
+.country-diff-group {
+  padding: 5px;
+
+  &:nth-child(even) {
+    background-color: transparentize($color-text-light-grey, 0.7);
+  }
+}
+
 @mixin link-diff-color($basecolor) {
   background-color: $basecolor;
 


### PR DESCRIPTION
Hier gab es ein Problem mit unveränderten Werten -- für die konnte kein Wert nachgeschlagen werden, weil der Diff `null` war.
Allerdings wird die letzte Änderung immer geklont, damit wir mit dem unveränderten Wert/leeren Diff die `aktueller Wert` Zeile füllen können. Bei den anderen Zelltypen klappt das, Currency ist aber ein Spezialfall beim Darstellen der Werte.