### PR TITLE
set header for keycloak

### DIFF
--- a/src/static/ServerConfigTool.js
+++ b/src/static/ServerConfigTool.js
@@ -51,7 +51,13 @@ const stripProxyPrefixes = prefixes => proxyReq => {
 
 const configProxy = (routes, defaultHandler = null) => {
   const proxy = createProxyServer({
-    changeOrigin: true // changes the origin of the host header to the target URL
+    changeOrigin: true,
+    xfwd: true,
+    // if keycloak's env PROXY_ADDRESS_FORWARDING=true then keycloak will set
+    // the cookie for the given `X-Forwarded-Url`
+    onProxyReq: (proxyReq, req) => {
+      proxyReq.setHeader("X-Forwarded-Url", req.originalUrl);
+    }
   });
   const prefixRegexes = routes.map(({ prefix }) => new RegExp("^" + prefix));
 


### PR DESCRIPTION
Ich weiß nicht genau, ob das die richtige Stelle ist. Wenn die Header gesetzt sind, funktioniert jedenfalls auth flow mit keycloak auch von verschiedenen Domains und Subdomains.