### PR TITLE
Feature/auth/refactor name editor

### DIFF
--- a/src/app/components/header/tableSettings/NameEditor.jsx
+++ b/src/app/components/header/tableSettings/NameEditor.jsx
@@ -28,7 +28,6 @@ const NameEditor = ({ table, langtag, changeTableName, locked }) => {
   const enterEditMode = useCallback(event => {
     stopPropagation(event);
     preventDefault(event);
-    console.log("enter edit mode");
     !locked && setEditMode(true);
   });
 

--- a/src/app/components/header/tableSettings/NameEditor.jsx
+++ b/src/app/components/header/tableSettings/NameEditor.jsx
@@ -44,7 +44,6 @@ const NameEditor = ({ table, langtag, changeTableName, locked }) => {
   });
 
   const saveValue = valueToSave => {
-    console.log(`saveValue(${valueToSave})`);
     if (valueToSave !== getTableDisplayName(table, langtag)) {
       changeTableName(table.id, { displayName: { [langtag]: valueToSave } });
     }

--- a/src/app/components/header/tableSettings/NameEditor.jsx
+++ b/src/app/components/header/tableSettings/NameEditor.jsx
@@ -1,11 +1,4 @@
-/*
- * Menu entry for the TableSettingsPopup
- * Displays a menu entry with localized text, turns into input when clicked.
- * Input value gets saved as current locale display name when input loses focus or recieves "Enter" key.
- * Aborts input on "Escape" key.
- */
 import React, { useState, useCallback, useEffect, useRef } from "react";
-import f from "lodash/fp";
 import i18n from "i18next";
 import listensToClickOutside from "react-onclickoutside";
 

--- a/src/app/components/header/tableSettings/NameEditor.jsx
+++ b/src/app/components/header/tableSettings/NameEditor.jsx
@@ -37,7 +37,6 @@ const NameEditor = ({ table, langtag, changeTableName, locked }) => {
   const clearInput = useCallback(() => setValue(""));
 
   const saveAndClose = useCallback(event => {
-    console.log("saveAndClose", value);
     preventDefault(event);
     stopPropagation(event);
     exitEditMode();

--- a/src/app/components/header/tableSettings/TableSettings.jsx
+++ b/src/app/components/header/tableSettings/TableSettings.jsx
@@ -48,7 +48,7 @@ class TableSettings extends React.Component {
             <TableSettingsPopup
               table={this.props.table}
               langtag={this.props.langtag}
-              outsideClickHandler={this.onClickOutside}
+              handleClickOutside={this.onClickOutside}
               actions={this.props.actions}
             />
           ) : null}

--- a/src/app/components/header/tableSettings/TableSettingsPopup.jsx
+++ b/src/app/components/header/tableSettings/TableSettingsPopup.jsx
@@ -14,60 +14,41 @@ import {
 } from "../../../helpers/accessManagementHelper";
 import NameEditor from "./NameEditor";
 
-@listensToClickOutside
-class TableSettingsPopup extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = { selected: null };
-  }
+const TableSettingsPopup = ({
+  table,
+  langtag,
+  actions: { setAllRowsFinal, changeTableName }
+}) => {
+  const canEditRowAnnotations = canUserEditRowAnnotations({ table });
+  const canEditTableDisplayProperty = canUserEditTableDisplayProperty({
+    table
+  });
+  return (
+    <div id="table-settings-popup">
+      <button
+        key="i-need-no-key"
+        className={
+          "menu-item " + (canEditRowAnnotations ? "" : "menu-item--disabled")
+        }
+        onClick={() => (canEditRowAnnotations ? setAllRowsFinal(table) : null)}
+      >
+        {i18n.t("table:final.set_all_rows_final")}
+      </button>
 
-  handleClickOutside = evt => {
-    this.props.outsideClickHandler(evt);
-  };
-
-  render() {
-    const {
-      table,
-      langtag,
-      actions: { setAllRowsFinal, changeTableName }
-    } = this.props;
-    const canEditRowAnnotations = canUserEditRowAnnotations({ table });
-    const canEditTableDisplayProperty = canUserEditTableDisplayProperty({
-      table
-    });
-    return (
-      <div id="table-settings-popup">
-        <div
-          className={canEditRowAnnotations ? "menu-item" : "menu-item-disabled"}
-          onClick={() =>
-            canEditRowAnnotations ? setAllRowsFinal(table) : null
-          }
-        >
-          <a key="i-need-no-key" href="#">
-            {i18n.t("table:final.set_all_rows_final")}
-          </a>
-        </div>
-        <div
-          className={
-            canEditTableDisplayProperty ? "menu-item" : "menu-item-disabled"
-          }
-        >
-          <NameEditor
-            table={table}
-            langtag={langtag}
-            changeTableName={changeTableName}
-            locked={!canEditTableDisplayProperty}
-          />
-        </div>
-      </div>
-    );
-  }
-}
+      <NameEditor
+        table={table}
+        langtag={langtag}
+        changeTableName={changeTableName}
+        locked={!canEditTableDisplayProperty}
+      />
+    </div>
+  );
+};
 
 TableSettingsPopup.propTypes = {
   table: PropTypes.object.isRequired,
   langtag: PropTypes.string.isRequired,
-  outsideClickHandler: PropTypes.func.isRequired
+  handleClickOutside: PropTypes.func.isRequired
 };
 
-export default TableSettingsPopup;
+export default listensToClickOutside(TableSettingsPopup);

--- a/src/app/components/header/tableSettings/TableSettingsPopup.jsx
+++ b/src/app/components/header/tableSettings/TableSettingsPopup.jsx
@@ -2,7 +2,7 @@
  * Content for the TableSettings menu. Entries are individual React items with specific functions.
  */
 
-import React, { PureComponent } from "react";
+import React from "react";
 import i18n from "i18next";
 import listensToClickOutside from "react-onclickoutside";
 

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -53,6 +53,17 @@ input, textarea {
   font-weight: lighter;
 }
 
+button {
+  background-color: transparent;
+  border: none;
+  padding: none;
+  margin: none;
+  font-size: 1.3rem;
+  font-family: "Roboto", Helvetica Neue, Helvetica, Arial, sans-serif;
+  text-align: left;
+  cursor: pointer;
+}
+
 .ReactVirtualized__List {
   overflow: hidden !important;
 

--- a/src/scss/tableSettings.scss
+++ b/src/scss/tableSettings.scss
@@ -1,14 +1,15 @@
 @import "helper";
 @import "variables";
 
-#table-rename-wrapper {
+.table-rename-wrapper {
   input {
     height: 30px;
     line-height: 30px;
     border: 1px solid $color-grey-dark;
     @include border-radius(3px);
     outline: none;
-    width: 200px;
+    width: 100%;
+    box-sizing: border-box;
     padding: 0 10px;
 
     &:focus, &:active {
@@ -32,27 +33,25 @@
       @include header-button-active();
     }
   }
+}
 
-  #table-settings-popup {
-    @include header-panel-look();
-    padding: 10px 0;
+#table-settings-popup {
+  @include header-panel-look();
+  padding: 0;
+  width: 200px;
 
-    .menu-item {
-      width: 100%;
-      padding: 10px 10px;
-      cursor: pointer;
-    }
-    .menu-item-disabled {
-      width: 100%;
-      padding: 10px 10px;
-      opacity: 0.5;
-      a {
-        cursor: default;
-      }
-    }
-    .menu-item:hover{
-      background-color: $color-light-link-color;
-    }
+  .menu-item {
+    width: 100%;
+    padding: 10px 10px;
+    cursor: pointer;
   }
 
+  .menu-item--disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .menu-item:hover{
+    background-color: $color-light-link-color;
+  }
 }


### PR DESCRIPTION
Speichert jetzt bei "Tabelle umbenennen" auch bei Schließen des Menüs, nicht nur wenn explizit nach Namen eintippen "Enter" gedrückt wurde.