### PR TITLE
Read feature flags from env

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -4,13 +4,7 @@ const Path = require("path");
 const Bundler = require("parcel-bundler");
 const ServerConfigTool = require("./src/static/ServerConfigTool.js");
 
-const config = ServerConfigTool.enrichConfig({
-  outDir: "out",
-  host: "localhost",
-  port: 3000,
-  apiHost: "localhost",
-  apiPort: 8080
-});
+const config = ServerConfigTool.enrichConfig({});
 
 const proxyHandlers = [
   {

--- a/src/app/FeatureFlags.js
+++ b/src/app/FeatureFlags.js
@@ -1,6 +1,3 @@
 export const ENABLE_DASHBOARD = true;
 export const SHOW_DASHBOARD_USER_NAME = true;
 export const KEYBOARD_TABLE_HISTORY = true;
-export const ENABLE_HISTORY = process.env.ENABLE_HISTORY !== "false";
-export const SHOW_TABLE_DROPDOWN = process.env.SHOW_TABLE_DROPDOWN !== "false";
-export const NO_AUTH_IN_DEV_MODE = false;

--- a/src/app/components/contextMenu/RowContextMenu.jsx
+++ b/src/app/components/contextMenu/RowContextMenu.jsx
@@ -7,7 +7,7 @@ import withClickOutside from "react-onclickoutside";
 import PropTypes from "prop-types";
 
 import { ColumnKinds, Langtags } from "../../constants/TableauxConstants";
-import { ENABLE_HISTORY } from "../../FeatureFlags";
+import { config } from "../../constants/TableauxConstants";
 import {
   addTranslationNeeded,
   deleteCellAnnotation,
@@ -355,7 +355,7 @@ class RowContextMenu extends React.Component {
                 "commenting-o"
               )
             : null}
-          {ENABLE_HISTORY &&
+          {config.enableHistory &&
           !f.contains(this.props.cell.kind, [
             ColumnKinds.group,
             ColumnKinds.concat

--- a/src/app/components/header/tableSettings/TableSettings.jsx
+++ b/src/app/components/header/tableSettings/TableSettings.jsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import PropTypes from "prop-types";
 
-import { SHOW_TABLE_DROPDOWN } from "../../../FeatureFlags";
+import { config } from "../../../constants/TableauxConstants";
 import TableSettingsPopup from "./TableSettingsPopup";
 
 class TableSettings extends React.Component {
@@ -32,7 +32,7 @@ class TableSettings extends React.Component {
   render = () => {
     const { open } = this.state;
     return (
-      SHOW_TABLE_DROPDOWN && (
+      config.showTableDropdown && (
         <div id="table-settings-wrapper" onClick={this.toggleSettingsPopup}>
           <a
             id="table-settings"

--- a/src/app/helpers/authenticate.jsx
+++ b/src/app/helpers/authenticate.jsx
@@ -4,7 +4,6 @@ import React from "react";
 import f from "lodash/fp";
 
 import { config } from "../constants/TableauxConstants";
-import { NO_AUTH_IN_DEV_MODE } from "../FeatureFlags";
 import actions from "../redux/actionCreators";
 import store from "../redux/store";
 
@@ -17,9 +16,7 @@ const keycloakInitOptions = {
 // react-redux@7 selector
 export const authSelector = f.propOr(false, ["grudStatus", "authenticated"]);
 
-export const noAuthNeeded = f.memoize(
-  () => process.env.NODE_ENV === "development" && NO_AUTH_IN_DEV_MODE
-);
+export const noAuthNeeded = f.memoize(() => config.disableAuth);
 
 // () => Keycloak
 // Side effects: Will login on first load and memoize the result

--- a/src/static/ServerConfigTool.js
+++ b/src/static/ServerConfigTool.js
@@ -25,8 +25,21 @@ const envParams = [
   "port",
   "webhookUrl",
   "authServerUrl",
-  "authRealm"
+  "authRealm",
+  "enableHistory",
+  "showTableDropdown",
+  "disableAuth"
 ];
+
+const configDefaults = {
+  enableHistory: true,
+  showTableDropdown: true,
+  outDir: "out",
+  apiHost: "localhost",
+  apiPort: 8080,
+  host: "0.0.0.0",
+  port: "3000"
+};
 
 const enrichConfig = config => {
   try {
@@ -39,7 +52,10 @@ const enrichConfig = config => {
       path.join(projectBaseDir, "config.json");
     console.error("Config file path", configFile);
     const localConfig = require(configFile);
-    config = { ...config, ...localConfig };
+    config = {
+      ...config,
+      ...localConfig
+    };
   } catch (err) {
     console.error("Warning: Could not read config file, using defaults");
   }
@@ -50,12 +66,17 @@ const enrichConfig = config => {
       process.env[envVar.toUpperCase()];
     if (envValue) {
       console.error("Overriding", envVar, "with", envValue, "from environment");
-      config[envVar] = envValue;
+      config[envVar] = envValue === "false" ? false : envValue;
+      try {
+        config[envVar] = JSON.parse(envValue); // extract bools and numbers
+      } catch {
+        config[envVar] = envValue;
+      }
     }
   };
 
   envParams.forEach(overrideConfigWithEnv);
-  return config;
+  return { ...configDefaults, ...config };
 };
 
 const upgradeAuthHeaders = req => {

--- a/src/static/grud-frontend-server.js
+++ b/src/static/grud-frontend-server.js
@@ -11,12 +11,7 @@ const ServerConfigTool = require("./ServerConfigTool");
 // Apply settings --------------------------------------------------------------
 
 const config = ServerConfigTool.enrichConfig({
-  // Default config, overriden by config file and env params
-  outDir: __dirname, // path to serve static files from
-  apiHost: "localhost", // api host
-  apiPort: 8080,
-  port: 3000,
-  host: "localhost"
+  outDir: __dirname // path to serve static files from
 });
 
 const proxyDestinations = [


### PR DESCRIPTION
Das erlaubt uns, Feature flags auch im Production mode beim Start des Servers zu setzen, somit muss man keinen dedizierten Rebuild mehr triggern um ein Featureflag zu setzen.