### PR TITLE
Fix CurrencyCell closing when clicking the scrollbar

### DIFF
--- a/src/app/components/cells/currency/CurrencyCell.jsx
+++ b/src/app/components/cells/currency/CurrencyCell.jsx
@@ -20,8 +20,6 @@ import {
 import CurrencyEditCell from "./CurrencyEditCell";
 import { when } from "../../../helpers/functools.js";
 
-const CurrencyEditCellWithClickOutside = onClickOutside(CurrencyEditCell);
-
 @translate(["table"])
 class CurrencyCell extends React.PureComponent {
   static propTypes = {
@@ -165,10 +163,9 @@ class CurrencyCell extends React.PureComponent {
     const currencyValues = value;
     const country = getCountryOfLangtag(langtag);
     const currencyCellMarkup = editing ? (
-      <CurrencyEditCellWithClickOutside
+      <CurrencyEditCell
         cell={this.props.cell}
         setCellKeyboardShortcuts={setCellKeyboardShortcuts}
-        onClickOutside={this.handleClickOutside}
         saveCell={this.saveCurrencyCell}
         exitCell={this.exitCurrencyCell}
       />
@@ -188,4 +185,4 @@ class CurrencyCell extends React.PureComponent {
     );
   }
 }
-export default CurrencyCell;
+export default onClickOutside(CurrencyCell);


### PR DESCRIPTION
Move onClickOutside from CurrencyEditCell to CurrencyCell

# Submit a pull request

Please make sure the following is true:

- [x ] This is not a duplicate of another PR
- [x ] The correct target branch selected?
- Breaking changes
  - [ x] No existing features have been broken (without good reason)
  - [ ] PR introduces breaking changes
- [x ] Commit messages are meaningful
- [x ] The behaviour is as the documentation describes, or you updated the docs
- Tests
  - [x ] Tests have been added/updated for new/modified unit-testable functions/helpers
  - [x ] Test were run and did pass
- [x ] The linter was run and did pass

## PR details
When clicking the scrollbar in a currency-cell, the cell closed.
Fixed by moving onClickOutside handler from CurrencyEditCell to CurrencyCell.

## Breaking changes

- What is broken, and why

## Other information/comments

- Anything to tell the world? :D
