### PR TITLE
add separator check to NumberDiff item

### DIFF
--- a/src/app/components/history/diffItems/Diff.jsx
+++ b/src/app/components/history/diffItems/Diff.jsx
@@ -50,7 +50,12 @@ const ContentDiff = props => {
     case ColumnKinds.currency:
       return <CountryDiff {...props} />;
     case ColumnKinds.numeric:
-      return <NumberDiff {...props} isRevertable={props.revision.revertable} />;
+      return (
+        <NumberDiff
+          {...props}
+          shouldFormatNumber={f.get(["cell", "column", "separator"], props)}
+        />
+      );
     case ColumnKinds.text:
     case ColumnKinds.shorttext:
     case ColumnKinds.richtext:

--- a/src/app/components/history/diffItems/NumberDiff.jsx
+++ b/src/app/components/history/diffItems/NumberDiff.jsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import { formatNumber } from "../../../helpers/multiLanguage";
 
 const NumberDiff = props => {
-  const { diff } = props;
+  const { diff, shouldFormatNumber = true } = props;
   return diff.map(({ add, del, value }, idx) => {
     const cssClass = classNames("content-diff", {
       "content-diff--added": add,
@@ -15,7 +15,7 @@ const NumberDiff = props => {
 
     return (
       <span key={idx} className={cssClass}>
-        {formatNumber(value)}
+        {shouldFormatNumber ? formatNumber(value) : value}
       </span>
     );
   });
@@ -23,5 +23,6 @@ const NumberDiff = props => {
 
 export default NumberDiff;
 NumberDiff.propTypes = {
-  diff: PropTypes.array.isRequired
+  diff: PropTypes.array.isRequired,
+  shouldFormatNumber: PropTypes.boolean
 };


### PR DESCRIPTION
# Submit a pull request

Please make sure the following is true:

- [x ] This is not a duplicate of another PR
- [x ] The correct target branch selected?
- Breaking changes
  - [ x] No existing features have been broken (without good reason)
  - [ ] PR introduces breaking changes
- [ x] Commit messages are meaningful
- [x ] The behaviour is as the documentation describes, or you updated the docs
- Tests
  - [ x] Tests have been added/updated for new/modified unit-testable functions/helpers
  - [x ] Test were run and did pass
- [x ] The linter was run and did pass

## PR details

NumberDiff Items in history always showed formatted number values with separator, now check for separator flag and format number only when needed.
Task: https://app.activecollab.com/116706/projects/2?modal=Task-21691-2
## Breaking changes

- What is broken, and why

## Other information/comments

- Anything to tell the world? :D
