### PR TITLE
Remove unnecessary table find

### DIFF
--- a/src/app/components/columns/ColumnHeader.jsx
+++ b/src/app/components/columns/ColumnHeader.jsx
@@ -1,5 +1,4 @@
 import React, { PureComponent } from "react";
-import f from "lodash/fp";
 
 import PropTypes from "prop-types";
 

--- a/src/app/components/columns/ColumnHeader.jsx
+++ b/src/app/components/columns/ColumnHeader.jsx
@@ -67,10 +67,7 @@ export default class ColumnHeader extends PureComponent {
       tableId,
       resizeIdHandler
     } = this.props;
-    const toTable =
-      column.kind === "link"
-        ? f.find(table => table.id === column.toTable, tables)
-        : {};
+    const toTable = column.kind === "link" ? { id: column.toTable } : {};
 
     const displayName = getColumnDisplayName(column, langtag);
 

--- a/src/app/components/columns/ColumnHeader.jsx
+++ b/src/app/components/columns/ColumnHeader.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from "react";
+import f from "lodash/fp";
 
 import PropTypes from "prop-types";
 
@@ -66,7 +67,10 @@ export default class ColumnHeader extends PureComponent {
       tableId,
       resizeIdHandler
     } = this.props;
-    const toTable = column.kind === "link" ? { id: column.toTable } : {};
+    const toTable =
+      (column.kind === "link" &&
+        f.find(table => table.id === column.toTable, tables)) ||
+      {};
 
     const displayName = getColumnDisplayName(column, langtag);
 


### PR DESCRIPTION
If a user is not allowed to see hidden tables, the find operation will
return null, leading to errors down the line. Remove it, as it isn't
necessary.

# Submit a pull request

Please make sure the following is true:

- [x] This is not a duplicate of another PR
- [x] The correct target branch selected?
- Breaking changes
  - [x] No existing features have been broken (without good reason)
  - [ ] PR introduces breaking changes
- [x] Commit messages are meaningful
- [x] The behaviour is as the documentation describes, or you updated the docs
- Tests
  - [x] Tests have been added/updated for new/modified unit-testable functions/helpers
  - [x] Test were run and did pass
- [x] The linter was run and did pass

## PR details

Fixes null error when trying to open ColumnEditor if user doesn't have permission to see hidden tables.
Task: https://app.activecollab.com/116706/projects/2?modal=Task-21698-2

## Breaking changes

- What is broken, and why

## Other information/comments

- Anything to tell the world? :D
