### PR TITLE
fix wrong column Index on keyboard cell copy

### DIFF
--- a/src/app/components/table/tableNavigationWorker.js
+++ b/src/app/components/table/tableNavigationWorker.js
@@ -558,12 +558,7 @@ function copySelectedCell() {
   } = store.getState();
 
   const rowIndex = f.findIndex(row => row.id === rowId, rows);
-  const visibleColumns = f.filter(col => col.visible || col.id === 0, columns);
-  const columnIndex = getColumnIdx(
-    columnId,
-    visibleColumns,
-    visibleColumnOrdering
-  );
+  const columnIndex = getColumnIdx(columnId, columns, visibleColumnOrdering);
 
   const cell = this.getCell(rowIndex, columnIndex);
 
@@ -587,8 +582,7 @@ function pasteSelectedCell() {
   } = store.getState();
 
   const rowIndex = f.findIndex(row => row.id === rowId, rows);
-  const vColumns = f.filter(col => col.visible || col.id === 0, columns);
-  const columnIndex = getColumnIdx(columnId, vColumns, visibleColumnOrdering);
+  const columnIndex = getColumnIdx(columnId, columns, visibleColumnOrdering);
 
   const selectedCellObject = this.getCell(rowIndex, columnIndex);
 


### PR DESCRIPTION
# Submit a pull request

Please make sure the following is true:

- [x] This is not a duplicate of another PR
- [x] The correct target branch selected?
- Breaking changes
  - [x] No existing features have been broken (without good reason)
  - [ ] PR introduces breaking changes
- [x] Commit messages are meaningful
- [x] The behaviour is as the documentation describes, or you updated the docs
- Tests
  - [ ] Tests have been added/updated for new/modified unit-testable functions/helpers
  - [ ] Test were run and did pass
- [x] The linter was run and did pass

## PR details
The copy and paste handlers in tableNavigationWorkers extracted the colum index from visible columns, leading to wrong indices in certain cases, fixed by using the whole columns array.
