### PR TITLE
fixed missing jest setup file for ci tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /usr/app
 
 COPY .npmrc ./
 COPY package* ./
+COPY setupTests.js ./
 
 RUN npm ci -d
 


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

<img width="925" alt="Screenshot 2021-07-15 at 10 03 00" src="https://user-images.githubusercontent.com/30567195/125753744-c7191dca-1113-417d-b98a-b7d1860237b2.png">

## Reason for this PR

Fix broken ci build due to missing jest setup file (setupTests.js) for ci tests.
`setupTests.js` was introduced in project-maintenance PR #272.