### PR TITLE
Bugfix/edit currency cell

### DIFF
--- a/src/app/helpers/accessManagementHelper.js
+++ b/src/app/helpers/accessManagementHelper.js
@@ -74,11 +74,11 @@ export const canUserChangeCell = (cellInfo, langtag) => {
   return allowed || noAuthNeeded(); // this special case is not caught by ALLOW_ANYTHING
 };
 
-export const canUserChangeAnyCountryTypeCell = cellInfo =>
-  cellInfo
-  |> getPermission(["column", "editCellValue"])
-  |> f.values
-  |> f.any(f.identity);
+export const canUserChangeAnyCountryTypeCell = (cellInfo) => {
+  const allowed =
+    cellInfo |> getPermission(["column", "editCellValue"]) |> f.values |> f.any(f.identity);
+  return allowed || noAuthNeeded();
+};
 
 export const canUserChangeCountryTypeCell = canUserChangeCell;
 export const canUserEditColumnDisplayProperty = getPermission([

--- a/src/app/helpers/accessManagementHelper.js
+++ b/src/app/helpers/accessManagementHelper.js
@@ -74,9 +74,12 @@ export const canUserChangeCell = (cellInfo, langtag) => {
   return allowed || noAuthNeeded(); // this special case is not caught by ALLOW_ANYTHING
 };
 
-export const canUserChangeAnyCountryTypeCell = (cellInfo) => {
+export const canUserChangeAnyCountryTypeCell = cellInfo => {
   const allowed =
-    cellInfo |> getPermission(["column", "editCellValue"]) |> f.values |> f.any(f.identity);
+    cellInfo
+    |> getPermission(["column", "editCellValue"])
+    |> f.values
+    |> f.any(f.identity);
   return allowed || noAuthNeeded();
 };
 


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR
Users were not able to edit Currenc Cells, because of a missing noAuthNeeded()
function call in the relevant accessManagementHelper. This bug only
presents itself if Auth is disabled.
