### PR TITLE
Fix LinkList not scrollable

### DIFF
--- a/src/app/components/helperComponents/LinkList.jsx
+++ b/src/app/components/helperComponents/LinkList.jsx
@@ -114,7 +114,7 @@ const LinkList = props => {
   };
 
   const ListRenderer = sortable ? (
-    <div className="sortable">
+    <div className={`sortable ${expanded && "sortable_expanded"}`}>
       <div className="linked-items">
         <LinkedRows
           entries={f.map("id", links)}
@@ -126,7 +126,7 @@ const LinkList = props => {
       </div>
     </div>
   ) : (
-    <div className="sortable">
+    <div className={`sortable ${expanded && "sortable_expanded"}`}>
       <div className="linked-items">
         <List
           width={window.innerWidth * 0.6 - 100}

--- a/src/scss/overlay.scss
+++ b/src/scss/overlay.scss
@@ -461,6 +461,10 @@ $dist-from-top: 20px;
     @import "./linkList.scss";
   }
 
+  .sortable_expanded {
+    overflow-y: scroll;
+  }
+
   .link-list {
     max-height: 430px;
     & > .can-expand {


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Reason for this PR
Fixes LinkView and AttachmentView in EntityView not being scrollable.
