### PR TITLE
Add cell context menu to open frontend services directly

### DIFF
--- a/src/app/components/GrudHeader.jsx
+++ b/src/app/components/GrudHeader.jsx
@@ -5,19 +5,16 @@ import f from "lodash/fp";
 import PropTypes from "prop-types";
 
 import { ConnectionStatus } from "./header/ConnectionStatus";
-import { filterMainMenuEntries } from "../frontendServiceRegistry/frontendServices";
 import LanguageSwitcher from "./header/LanguageSwitcher";
 import Navigation from "./header/Navigation";
 import PageTitle from "./header/PageTitle";
 
 const mapStateToProps = state => {
-  const services = state.frontendServices || [];
   const connectedToBackend = f.prop(["grudStatus", "connectedToBackend"])(
     state
   );
 
   return {
-    services,
     connectedToBackend
   };
 };
@@ -27,15 +24,11 @@ const GrudHeader = ({
   handleLanguageSwitch,
   langtag,
   pageTitleOrKey,
-  connectedToBackend,
-  services
+  connectedToBackend
 }) => (
   <div className="grud-header-wrapper">
     <header className="grud-header">
-      <Navigation
-        langtag={langtag}
-        services={services.filter(filterMainMenuEntries)}
-      />
+      <Navigation langtag={langtag} />
       {children || <div className="header-separator" />}
       <PageTitle titleKey={pageTitleOrKey} />
       <LanguageSwitcher langtag={langtag} onChange={handleLanguageSwitch} />

--- a/src/app/components/contextMenu/RowContextMenu.jsx
+++ b/src/app/components/contextMenu/RowContextMenu.jsx
@@ -1,13 +1,22 @@
-import { compose } from "recompose";
-import { translate } from "react-i18next";
-import React from "react";
 import f from "lodash/fp";
-import withClickOutside from "react-onclickoutside";
-
 import PropTypes from "prop-types";
-
-import { ColumnKinds, Langtags } from "../../constants/TableauxConstants";
-import { config } from "../../constants/TableauxConstants";
+import React from "react";
+import { translate } from "react-i18next";
+import withClickOutside from "react-onclickoutside";
+import { compose } from "recompose";
+import pasteCellValue from "../../components/cells/cellCopyHelper";
+import {
+  ColumnKinds,
+  config,
+  Langtags
+} from "../../constants/TableauxConstants";
+import {
+  canUserChangeCell,
+  canUserCreateRow,
+  canUserDeleteRow,
+  canUserEditCellAnnotations,
+  canUserEditRowAnnotations
+} from "../../helpers/accessManagementHelper";
 import {
   addTranslationNeeded,
   deleteCellAnnotation,
@@ -17,23 +26,16 @@ import {
   setRowFinal
 } from "../../helpers/annotationHelper";
 import { canConvert } from "../../helpers/cellValueConverter";
-import {
-  canUserChangeCell,
-  canUserEditRowAnnotations,
-  canUserEditCellAnnotations,
-  canUserCreateRow,
-  canUserDeleteRow
-} from "../../helpers/accessManagementHelper";
+import { merge } from "../../helpers/functools";
 import {
   initiateDeleteRow,
   initiateDuplicateRow,
   initiateEntityView,
   initiateRowDependency
 } from "../../helpers/rowHelper";
-import { merge } from "../../helpers/functools";
+import ContextMenuServices from "../frontendService/ContextMenuEntries";
 import { openHistoryOverlay } from "../history/HistoryOverlay";
 import GenericContextMenu from "./GenericContextMenu";
-import pasteCellValue from "../../components/cells/cellCopyHelper";
 
 // Distance between clicked coordinate and the left upper corner of the context menu
 const CLICK_OFFSET = 3;
@@ -371,7 +373,7 @@ class RowContextMenu extends React.Component {
           {this.toggleFlagItem("important")}
           {this.toggleFlagItem("check-me")}
           {this.toggleFlagItem("postpone")}
-
+          <ContextMenuServices cell={cell} langtag={this.props.langtag} />
           <div className="separator with-line">{t("menus.data_set")}</div>
           {this.props.table.type === "settings"
             ? ""

--- a/src/app/components/frontendService/ContextMenuEntries.jsx
+++ b/src/app/components/frontendService/ContextMenuEntries.jsx
@@ -1,0 +1,47 @@
+import f from "lodash/fp";
+import React from "react";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import {
+  filterCellServices,
+  getAllServices
+} from "../../frontendServiceRegistry/frontendServices";
+import route from "../../helpers/apiRoutes";
+import { retrieveTranslation as t } from "../../helpers/multiLanguage";
+
+const ContextMenuItem = ({ label, icon, url }) => {
+  return (
+    <Link to={url} className="context-menu__item">
+      <i className={`context-menu__icon fa fa-${icon}`} />
+      <div className="context-menu__item-label item-label">{label}</div>
+    </Link>
+  );
+};
+
+const ContextMenuServices = ({ cell, langtag }) => {
+  const services = useSelector(
+    f.compose(
+      filterCellServices(cell),
+      getAllServices
+    )
+  );
+  const { table, column, row } = cell;
+
+  return services.length > 0 ? (
+    <>
+      {services.map(s => {
+        const label = t(langtag, s.displayName);
+        const url = route.toFrontendServiceView(s.id, langtag, {
+          tableId: table.id,
+          rowId: row.id,
+          columnId: column.id
+        });
+
+        return <ContextMenuItem key={s.name} label={label} url={url} />;
+      })}
+    </>
+  ) : null;
+};
+
+ContextMenuServices.displayName = "ContextMenuServices";
+export default ContextMenuServices;

--- a/src/app/components/frontendService/ServiceConstants.js
+++ b/src/app/components/frontendService/ServiceConstants.js
@@ -1,0 +1,6 @@
+export const ScopeType = {
+  cell: "cell",
+  column: "column",
+  global: "global",
+  table: "table"
+};

--- a/src/app/components/header/Navigation.jsx
+++ b/src/app/components/header/Navigation.jsx
@@ -2,10 +2,22 @@ import React from "react";
 import NavigationPopup from "./NavigationPopup";
 import PropTypes from "prop-types";
 import listensToClickOutside from "react-onclickoutside";
+import { useSelector } from "react-redux";
+import f from "lodash/fp";
+import {
+  filterMainMenuServices,
+  getAllServices
+} from "../../frontendServiceRegistry/frontendServices";
 
 const SelfClosingNavigationPopup = listensToClickOutside(NavigationPopup);
 
-const Navigation = ({ langtag, services }) => {
+const Navigation = ({ langtag }) => {
+  const services = useSelector(
+    f.compose(
+      filterMainMenuServices,
+      getAllServices
+    )
+  );
   const [popupOpen, setPopup] = React.useState(false);
   const closePopup = React.useCallback(() => setPopup(false));
   const togglePopup = React.useCallback(() => setPopup(!popupOpen));

--- a/src/app/frontendServiceRegistry/frontendServiceHelper.js
+++ b/src/app/frontendServiceRegistry/frontendServiceHelper.js
@@ -29,7 +29,7 @@ const anyMatches = (constraint, element) =>
     return matches || checkAsRegExp(check, value);
   }, false);
 
-const isServiceAllowed = (constraint, element) => {
+export const isServiceAllowed = (constraint, element) => {
   const { includes, excludes } = constraint;
   if (includes || excludes) {
     return allMatch(includes, element) && !anyMatches(excludes, element);

--- a/src/app/frontendServiceRegistry/frontendServiceHelper.js
+++ b/src/app/frontendServiceRegistry/frontendServiceHelper.js
@@ -10,3 +10,40 @@ export const expandServiceUrl = f.curryN(2, (values, serviceUrl) => {
     serviceUrl
   );
 });
+
+const checkAsRegExp = (reString, value) => new RegExp(reString).test(value);
+
+const allMatch = (constraint, element) =>
+  f.keys(constraint).reduce((allowed, key) => {
+    const check = constraint[key];
+    const value = f.prop(key, element);
+
+    return allowed && checkAsRegExp(check, value);
+  }, true);
+
+const anyMatches = (constraint, element) =>
+  f.keys(constraint).reduce((matches, key) => {
+    const check = constraint[key];
+    const value = f.prop(key, element);
+
+    return matches || checkAsRegExp(check, value);
+  }, false);
+
+const isServiceAllowed = (constraint, element) => {
+  const { includes, excludes } = constraint;
+  if (includes || excludes) {
+    return allMatch(includes, element) && !anyMatches(excludes, element);
+  } else {
+    return allMatch(constraint, element);
+  }
+};
+
+export const isServiceForTable = f.curryN(2, (table, service) => {
+  const tableConstraint = f.prop("scope.tables", service);
+  return tableConstraint ? isServiceAllowed(tableConstraint, table) : true;
+});
+
+export const isServiceForColumn = f.curryN(2, (column, service) => {
+  const columnConstraint = f.prop("scope.columns", service);
+  return columnConstraint ? isServiceAllowed(columnConstraint, column) : true;
+});

--- a/src/app/frontendServiceRegistry/frontendServiceHelper.test.js
+++ b/src/app/frontendServiceRegistry/frontendServiceHelper.test.js
@@ -1,4 +1,4 @@
-import { expandServiceUrl } from "./frontendServiceHelper";
+import { expandServiceUrl, isServiceAllowed } from "./frontendServiceHelper";
 
 describe("frontend service helper", () => {
   const values = { firstName: "Monty", lastName: "Python" };
@@ -13,6 +13,60 @@ describe("frontend service helper", () => {
     it("expands arbitrary moustaches", () => {
       expect(expandServiceUrl(values, urlTemplate)).toEqual(
         "/person/Python/Monty"
+      );
+    });
+  });
+
+  describe("isServiceAllowed()", () => {
+    const column = {
+      id: 1,
+      ordering: 1,
+      name: "state",
+      kind: "shorttext",
+      multilanguage: false,
+      identifier: true,
+      displayName: { "de-DE": "Bundesland", "en-GB": "federal state" },
+      description: {
+        "de-DE":
+          "Ein Land ist nach der föderalen Verfassungsordnung der Bundesrepublik Deutschland einer ihrer teilsouveränen Gliedstaaten.",
+        "en-GB":
+          "Germany is a federal republic consisting of sixteen federal states (German: Bundesland, or Land)."
+      },
+      separator: true,
+      status: "ok"
+    };
+    it("should allow tables with plain matches", () => {
+      expect(isServiceAllowed({ name: "state" }, column)).toBe(true);
+      expect(
+        isServiceAllowed({ "displayName.de-DE": "Bundesland" }, column)
+      ).toBe(true);
+    });
+
+    it("should allow tables with plain regex matches", () => {
+      expect(isServiceAllowed({ name: ".*ate.*" }, column)).toBe(true);
+    });
+
+    it("should deny tables with plain matches", () => {
+      expect(isServiceAllowed({ name: "country" }, column)).toBe(false);
+    });
+
+    it("should deny tables with plain regex matches", () => {
+      expect(isServiceAllowed({ name: ".*drank.*" }, column)).toBe(false);
+    });
+
+    it("should allow tables matching include clause", () => {
+      expect(isServiceAllowed({ includes: { name: ".*ate.*" } }, column)).toBe(
+        true
+      );
+    });
+    it("should deny tables not matching `includes` clause", () => {
+      expect(
+        isServiceAllowed({ includes: { name: ".*drank.*" } }, column)
+      ).toBe(false);
+    });
+    it("should deny tables matching `excludes` clause", () => {
+      expect(isServiceAllowed({ excludes: { name: ".*ate.*" } }, column)).toBe(
+        false
       );
     });
   });

--- a/src/app/frontendServiceRegistry/frontendServices.js
+++ b/src/app/frontendServiceRegistry/frontendServices.js
@@ -1,23 +1,34 @@
 import f from "lodash/fp";
+import { ScopeType } from "../components/frontendService/ServiceConstants";
 
 import actions from "../redux/actionCreators";
 import store from "../redux/store";
+import { isServiceForColumn, isServiceForTable } from "./frontendServiceHelper";
 
 // fetches from the service registry and writes results to redux store
 export const requestAvailableServices = () => {
   store.dispatch(actions.queryFrontendServices());
 };
 
-export const filterMainMenuEntries = f.compose(
+export const filterMainMenuServices = f.compose(
   f.sortBy(f.prop("ordering")),
-  f.filter(isGlobalService)
+  f.filter(x => isGlobalService(x))
 );
 
-export const getMainMenuEntryServices = () =>
-  f.compose(
-    filterMainMenuEntries,
-    getServiceArray
-  )(store.getState());
+export const filterCellServices = cell => {
+  const { table, column } = cell;
 
-const getServiceArray = f.prop("frontendServices");
-const isGlobalService = f.propEq(["scope", "type"], "global");
+  return f.compose(
+    f.sortBy(f.prop("ordering")),
+    f.filter(
+      f.allPass([
+        f.propEq("scope.type", ScopeType.cell),
+        isServiceForTable(table),
+        isServiceForColumn(column)
+      ])
+    )
+  );
+};
+
+export const getAllServices = f.prop("frontendServices");
+const isGlobalService = f.propEq("scope.type", ScopeType.global);

--- a/src/app/helpers/apiRoutes.js
+++ b/src/app/helpers/apiRoutes.js
@@ -6,6 +6,20 @@ const cleanUrlPart = f.flow(
 );
 const joinUrlParts = (...args) => args.map(cleanUrlPart).join("/");
 
+const toQSValue = (key, value) => `${key}=${encodeURIComponent(value)}`;
+export const toQueryString = params =>
+  f.compose(
+    f.reduce(
+      (query, [key, value]) =>
+        `${query}&` +
+        (Array.isArray(value)
+          ? value.map(v => toQSValue(key, v)).join("&")
+          : toQSValue(key, value)),
+      ""
+    ),
+    f.toPairs
+  )(params);
+
 const getAllTables = () => "/tables";
 
 const getAllColumnsForTable = tableId => "/tables/" + tableId + "/columns";
@@ -36,8 +50,19 @@ const toFile = (fileId, langtag) =>
   (langtag ? "?langtag=" + langtag : "");
 
 const toServiceRegistry = () => "/system/services";
-const toFrontendServiceView = (id, langtag) =>
-  "/" + langtag + "/services/" + id;
+const toFrontendServiceView = (id, langtag, params) => {
+  const baseUrl = `/${langtag}/services/${id}`;
+  return f.compose(
+    str => `${str}?${toQueryString(params)}`,
+    f.join("/"),
+    f.compact
+  )([
+    baseUrl,
+    params.tableId && `tables/${params.tableId}`,
+    params.columnId && `columns/${params.columnId}`,
+    params.rowId && `rows/${params.rowId}`
+  ]);
+};
 
 const toCellHistory = ({ tableId, rowId, columnId }) =>
   toCell({ tableId, rowId, columnId }) + "/history";


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Um alles etwas einheitlicher und lokaler handhaben zu können habe ich die Services im Navigationsmenü auch noch etwas refactored.