### PR TITLE
Allow opening frontend services in new tabs

### DIFF
--- a/src/app/components/frontendService/ContextMenuEntries.jsx
+++ b/src/app/components/frontendService/ContextMenuEntries.jsx
@@ -27,7 +27,6 @@ const ContextMenuServices = ({ cell, langtag }) => {
         return (
           <ServiceLink
             key={s.id}
-            to={url}
             classNames="context-menu__item"
             service={s}
             langtag={langtag}

--- a/src/app/components/frontendService/ContextMenuEntries.jsx
+++ b/src/app/components/frontendService/ContextMenuEntries.jsx
@@ -5,6 +5,7 @@ import {
   filterCellServices,
   getAllServices
 } from "../../frontendServiceRegistry/frontendServices";
+import ServiceIcon from "../../frontendServiceRegistry/ServiceIcon";
 import route from "../../helpers/apiRoutes";
 import { retrieveTranslation as t } from "../../helpers/multiLanguage";
 import ServiceLink from "./ServiceLink";
@@ -36,7 +37,7 @@ const ContextMenuServices = ({ cell, langtag }) => {
               columnId: column.id
             }}
           >
-            <i className={`context-menu__icon fa fa-${s.icon}`} />
+            <ServiceIcon classNames="context-menu__icon" service={s} />
             <div className="context-menu__item-label item-label">{label}</div>
           </ServiceLink>
         );

--- a/src/app/components/frontendService/ContextMenuEntries.jsx
+++ b/src/app/components/frontendService/ContextMenuEntries.jsx
@@ -1,22 +1,13 @@
 import f from "lodash/fp";
 import React from "react";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 import {
   filterCellServices,
   getAllServices
 } from "../../frontendServiceRegistry/frontendServices";
 import route from "../../helpers/apiRoutes";
 import { retrieveTranslation as t } from "../../helpers/multiLanguage";
-
-const ContextMenuItem = ({ label, icon, url }) => {
-  return (
-    <Link to={url} className="context-menu__item">
-      <i className={`context-menu__icon fa fa-${icon}`} />
-      <div className="context-menu__item-label item-label">{label}</div>
-    </Link>
-  );
-};
+import ServiceLink from "./ServiceLink";
 
 const ContextMenuServices = ({ cell, langtag }) => {
   const services = useSelector(
@@ -26,18 +17,29 @@ const ContextMenuServices = ({ cell, langtag }) => {
     )
   );
   const { table, column, row } = cell;
-
   return services.length > 0 ? (
     <>
       {services.map(s => {
         const label = t(langtag, s.displayName);
-        const url = route.toFrontendServiceView(s.id, langtag, {
-          tableId: table.id,
-          rowId: row.id,
-          columnId: column.id
-        });
+        const url = route.toFrontendServiceView(s.id, langtag);
 
-        return <ContextMenuItem key={s.name} label={label} url={url} />;
+        return (
+          <ServiceLink
+            key={s.id}
+            to={url}
+            classNames="context-menu__item"
+            service={s}
+            langtag={langtag}
+            params={{
+              tableId: table.id,
+              rowId: row.id,
+              columnId: column.id
+            }}
+          >
+            <i className={`context-menu__icon fa fa-${s.icon}`} />
+            <div className="context-menu__item-label item-label">{label}</div>
+          </ServiceLink>
+        );
       })}
     </>
   ) : null;

--- a/src/app/components/frontendService/ContextMenuEntries.jsx
+++ b/src/app/components/frontendService/ContextMenuEntries.jsx
@@ -6,7 +6,6 @@ import {
   getAllServices
 } from "../../frontendServiceRegistry/frontendServices";
 import ServiceIcon from "../../frontendServiceRegistry/ServiceIcon";
-import route from "../../helpers/apiRoutes";
 import { retrieveTranslation as t } from "../../helpers/multiLanguage";
 import ServiceLink from "./ServiceLink";
 

--- a/src/app/components/frontendService/ContextMenuEntries.jsx
+++ b/src/app/components/frontendService/ContextMenuEntries.jsx
@@ -22,7 +22,6 @@ const ContextMenuServices = ({ cell, langtag }) => {
     <>
       {services.map(s => {
         const label = t(langtag, s.displayName);
-        const url = route.toFrontendServiceView(s.id, langtag);
 
         return (
           <ServiceLink

--- a/src/app/components/frontendService/MainMenuEntry.jsx
+++ b/src/app/components/frontendService/MainMenuEntry.jsx
@@ -1,21 +1,15 @@
-import React from "react";
-
 import PropTypes from "prop-types";
-
-import { retrieveTranslation } from "../../helpers/multiLanguage";
-import { Link } from "react-router-dom";
+import React from "react";
 import ServiceIcon from "../../frontendServiceRegistry/ServiceIcon";
-import route from "../../helpers/apiRoutes";
+import { retrieveTranslation } from "../../helpers/multiLanguage";
+import ServiceLink from "./ServiceLink";
 
-const MainMenuEntry = ({ service, service: { displayName, id }, langtag }) => (
+const MainMenuEntry = ({ service, service: { displayName }, langtag }) => (
   <li className="main-navigation__entry">
-    <Link
-      to={route.toFrontendServiceView(id, langtag)}
-      className="main-navigation__entry-button"
-    >
+    <ServiceLink classNames="main-navigation__entry-button" langtag={langtag}>
       <ServiceIcon service={service} />
       {retrieveTranslation(langtag, displayName)}
-    </Link>
+    </ServiceLink>
   </li>
 );
 

--- a/src/app/components/frontendService/ServiceLink.jsx
+++ b/src/app/components/frontendService/ServiceLink.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import f from "lodash/fp";
+import { Link } from "react-router-dom";
+import { expandServiceUrl } from "../../frontendServiceRegistry/frontendServiceHelper";
+import route from "../../helpers/apiRoutes";
+
+const shouldOpenInNewTab = f.propEq("config.target", "_blank");
+
+const ServiceLink = ({ service, langtag, params = {}, children, classNames }) =>
+  shouldOpenInNewTab(service) ? (
+    <a
+      className={classNames}
+      href={expandServiceUrl({ ...params, langtag }, service.config.url)}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  ) : (
+    <Link
+      to={route.toFrontendServiceView(service.id, langtag, {
+        ...params,
+        langtag
+      })}
+    >
+      {children}
+    </Link>
+  );
+
+ServiceLink.displayName = "ServiceLink";
+export default ServiceLink;

--- a/src/app/components/frontendService/ServiceLink.jsx
+++ b/src/app/components/frontendService/ServiceLink.jsx
@@ -18,6 +18,7 @@ const ServiceLink = ({ service, langtag, params = {}, children, classNames }) =>
     </a>
   ) : (
     <Link
+      classNames={classNames}
       to={route.toFrontendServiceView(service.id, langtag, {
         ...params,
         langtag

--- a/src/app/frontendServiceRegistry/ServiceIcon.jsx
+++ b/src/app/frontendServiceRegistry/ServiceIcon.jsx
@@ -23,7 +23,7 @@ const ImageIcon = ({ url, base64 }) => {
 
 const FontIcon = ({ fontIconKey }) => <i className={"fa " + fontIconKey} />;
 
-const ServiceIcon = ({ service }) => {
+const ServiceIcon = ({ service, classNames }) => {
   const iconConfig = f.prop(["config", "icon"], service);
   const serviceHasIcon =
     iconConfig &&
@@ -38,8 +38,10 @@ const ServiceIcon = ({ service }) => {
       : "image"
     : ImageTypes.IMAGE;
 
+  const cssClass = `service-icon ${classNames || ""}`;
+
   return (
-    <div className="service-icon">
+    <div className={cssClass}>
       {serviceHasIcon ? (
         iconType === ImageTypes.FONT ? (
           <FontIcon fontIconKey={iconConfig.fontAwesome} />

--- a/src/app/frontendServiceRegistry/frontendServiceHelper.js
+++ b/src/app/frontendServiceRegistry/frontendServiceHelper.js
@@ -1,5 +1,4 @@
 import f from "lodash/fp";
-
 import { replaceMoustache } from "../helpers/functools";
 
 export const expandServiceUrl = f.curryN(2, (values, serviceUrl) => {


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Reason for this PR

Our service item specification lists an optional `config.target`-property which should cause service entries to open in new tabs if set to `_blank`.

This PR also adds the generic `ServiceIcon` component to the context menu entries. Take care when using large images/SVGs as icons!

Remaining differences to the frontend service spec:

- not all service types are supported yet (most lack specification details)
- only the following scopes are used: `global`, `cell`