### PR TITLE
AC-971: Temporary display switching markdown modes

### DIFF
--- a/src/app/components/markdownEditor/PlainMarkdownEditor.jsx
+++ b/src/app/components/markdownEditor/PlainMarkdownEditor.jsx
@@ -24,10 +24,13 @@ const PlainMarkdownEditor = (
   const [markdown, setMarkdown] = React.useState(initialMarkdown || "");
   const editorRef = React.useRef();
 
-  const [markdownPreview, setMarkdownPreview] = useLocalStorage(
-    "markdownPreview",
-    PreviewModes.HORIZONTAL
-  );
+  // FIXME: Other preview modes' display components problematic with current
+  // CodeMirror versions
+  const markdownPreview = PreviewModes.HORIZONTAL;
+  // const [markdownPreview, setMarkdownPreview] = useLocalStorage(
+  //   "markdownPreview",
+  //   PreviewModes.HORIZONTAL
+  // );
 
   const cssClass = classNames("plain-markdown-editor", className, {
     "markdown-editor--split-h": markdownPreview === PreviewModes.HORIZONTAL,
@@ -52,27 +55,28 @@ const PlainMarkdownEditor = (
   });
 
   const previewSelectorControls = [
-    {
-      key: PreviewModes.NONE,
-      toggleStyle: setMarkdownPreview,
-      styleToToggle: PreviewModes.NONE,
-      active: markdownPreview === PreviewModes.NONE,
-      iconComponent: <SvgIcon icon="layoutPlain" />
-    },
-    {
-      key: PreviewModes.VERTICAL,
-      toggleStyle: setMarkdownPreview,
-      styleToToggle: PreviewModes.VERTICAL,
-      active: markdownPreview === PreviewModes.VERTICAL,
-      iconComponent: <SvgIcon icon="layoutV" />
-    },
-    {
-      key: PreviewModes.HORIZONTAL,
-      toggleStyle: setMarkdownPreview,
-      styleToToggle: PreviewModes.HORIZONTAL,
-      active: markdownPreview === PreviewModes.HORIZONTAL,
-      iconComponent: <SvgIcon icon="layoutH" />
-    }
+    // FIXME: see above
+    // {
+    //   key: PreviewModes.NONE,
+    //   toggleStyle: setMarkdownPreview,
+    //   styleToToggle: PreviewModes.NONE,
+    //   active: markdownPreview === PreviewModes.NONE,
+    //   iconComponent: <SvgIcon icon="layoutPlain" />
+    // },
+    // {
+    //   key: PreviewModes.VERTICAL,
+    //   toggleStyle: setMarkdownPreview,
+    //   styleToToggle: PreviewModes.VERTICAL,
+    //   active: markdownPreview === PreviewModes.VERTICAL,
+    //   iconComponent: <SvgIcon icon="layoutV" />
+    // },
+    // {
+    //   key: PreviewModes.HORIZONTAL,
+    //   toggleStyle: setMarkdownPreview,
+    //   styleToToggle: PreviewModes.HORIZONTAL,
+    //   active: markdownPreview === PreviewModes.HORIZONTAL,
+    //   iconComponent: <SvgIcon icon="layoutH" />
+    // }
   ];
 
   return (


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Reason for this PR

Disable mode switching buttons and always shows the rich text editor in horizontal split mode, as CodeMirror does not use correct mouse pointer/caret positions when selecting text.