### PR TITLE
Harden HeaderPopupMenu

### DIFF
--- a/src/app/components/overlay/EntityView/HeaderPopupMenu.jsx
+++ b/src/app/components/overlay/EntityView/HeaderPopupMenu.jsx
@@ -106,8 +106,10 @@ class HeaderPopupMenu extends Component {
     } = this.props;
     const tableId = table.id;
 
-    const rowDataOfTable = grudData.rows[tableId].data;
-    const row = f.head(f.filter(row => row.id === cell.row.id, rowDataOfTable));
+    const row = f.compose(
+      f.find(row => row.id === cell.row.id),
+      f.propOr([], `rows.${tableId}.data`)
+    )(grudData);
     const { open } = this.state;
     const buttonClass = classNames("popup-button", { "is-open": open });
     const cells = f.get(["row", "cells"], this.props);
@@ -139,7 +141,7 @@ class HeaderPopupMenu extends Component {
             <SvgIcon icon="vdots" containerClasses="color-white" />
           </a>
         </div>
-        {open ? (
+        {row && open ? (
           <div className="popup-wrapper">
             <div
               className="popup"


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Hier passiert es live in einer Tabelle, dass das Overlay crasht, weil `rows[tableId]` `undefined` ist und deswegen nicht auf `.data` zugegriffen werden kann.  
Vermutlich liegt das an einem Timing-Problem, und es wird ein Re-Render getriggert, während die entsprechende Tabelle gerade noch geladen wird. Da die so gefundene Zeile erst nach dem Öffnen des Popup-Menüs überhaupt gebraucht werden wurden die Aufrufe so abgeändert, dass sie gegen `nil` toleranter sind.