### PR TITLE
Hide `hidden` columns

### DIFF
--- a/src/app/components/cells/text/ShortTextCell.jsx
+++ b/src/app/components/cells/text/ShortTextCell.jsx
@@ -24,7 +24,7 @@ const ShortTextCell = props => {
 
   const originalValue = isMultiLang ? value[langtag] : value;
 
-  const [editorValue, setEditorValue] = useState(originalValue);
+  const [editorValue, setEditorValue] = useState(originalValue || "");
   const saveEdits = () => handleEditDone(editorValue);
   const handleFinish = (shouldSave = true, finalValue = undefined) => {
     if (shouldSave) {

--- a/src/app/components/header/ColumnFilter.jsx
+++ b/src/app/components/header/ColumnFilter.jsx
@@ -24,8 +24,18 @@ class ColumnFilter extends React.Component {
       columns,
       tableId,
       columnActions,
-      columnOrdering
+      columnOrdering: rawColumnOrdering
     } = this.props;
+    const objIdces = columns.reduce((lookupTable, col, idx) => {
+      if (!col.hidden) lookupTable[col.id] = idx;
+      return lookupTable;
+    }, {});
+    const columnOrdering = rawColumnOrdering.reduce((ordering, val) => {
+      const idx = objIdces[val.id];
+      if (f.isNumber(idx)) ordering.push({ id: val.id, idx });
+      return ordering;
+    }, []);
+
     const { open } = this.state;
     const nHidden = f.flow(
       f.drop(1),


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Blended `hidden` Spalten in der Tabellenansicht sowie im Spaltenfilter aus.  

1. Versteckte Werte werden bei allen Berechnungen (Filter "irgendeine Spalte enthält", Status, Werte von Group-Columns, ...) weiter berücksichtigt.  
2. Die Sichtbarkeit wird zweimal redundant auf leicht verschiedene Arten berechnet; das erspart uns aber, bei allen möglichen Operationen auf dem Redux-State entscheiden zu müssen ob wir die Sichtbarkeit mit einrechnen müssen oder nicht (wird sie immer, siehe 1.).

Die Lösung ist vom Code her sicher nicht die schönstmögliche, allerdings äußerst pragmatisch und effektiv.