### PR TITLE
[Taxonomy]: Minimal tree renderer

### DIFF
--- a/src/app/components/Router.jsx
+++ b/src/app/components/Router.jsx
@@ -34,6 +34,8 @@ const GRUDRouter = React.memo(() => {
     renderView(ViewNames.DASHBOARD_VIEW)
   );
 
+  const renderTaxonomyDashboard = renderView(ViewNames.TAXONOMY_DASHBOARD_VIEW);
+
   const renderTableView = React.useCallback(routeProps => {
     const validParams = validateRouteParams(routeProps.match.params, tables);
     const { tableId } = validParams;
@@ -78,6 +80,7 @@ const GRUDRouter = React.memo(() => {
     <Router>
       <Switch>
         <Route path="/:langtag?/dashboard" render={renderDashboard} />
+        <Route path="/:langtag?/taxonomies" render={renderTaxonomyDashboard} />
         <Route
           path="/:langtag?/(table|tables)/:tableId?/(columns)?/:columnId?/(rows)?/:rowId?"
           render={renderTableView}

--- a/src/app/components/ViewRenderer.jsx
+++ b/src/app/components/ViewRenderer.jsx
@@ -7,6 +7,7 @@ import FrontendServiceView from "./frontendService/FrontendServiceView";
 import MediaView from "../components/media/MediaView.jsx";
 import TableView from "./tableView/TableView.jsx";
 import reduxActionHoc from "../helpers/reduxActionHoc";
+import TaxonomyDashboard from "./taxonomy/TaxonomyDashboard";
 
 const viewNameIs = name => f.matchesProperty("viewName", name);
 
@@ -25,11 +26,16 @@ const renderFrontendService = ({ params }) => (
   <FrontendServiceView {...params} />
 );
 
+const renderTaxonomyDashboard = props => (
+  <TaxonomyDashboard {...props.params} history={history} />
+);
+
 const ViewRenderer = f.cond([
   [viewNameIs(ViewNames.TABLE_VIEW), renderTableView],
   [viewNameIs(ViewNames.MEDIA_VIEW), renderMediaView],
   [viewNameIs(ViewNames.DASHBOARD_VIEW), renderDashboard],
-  [viewNameIs(ViewNames.FRONTEND_SERVICE_VIEW), renderFrontendService]
+  [viewNameIs(ViewNames.FRONTEND_SERVICE_VIEW), renderFrontendService],
+  [viewNameIs(ViewNames.TAXONOMY_DASHBOARD_VIEW), renderTaxonomyDashboard]
 ]);
 
 export default reduxActionHoc(ViewRenderer, () => {

--- a/src/app/components/cells/link/LinkOverlay.jsx
+++ b/src/app/components/cells/link/LinkOverlay.jsx
@@ -27,6 +27,7 @@ import LinkOverlayHeader from "./LinkOverlayHeader";
 import withCachedLinks from "./LinkOverlayCache.jsx";
 import { isTaxonomyTable } from "../../taxonomy/taxonomy";
 import store from "../../../redux/store";
+import { buildClassName } from "../../../helpers/buildClassName";
 
 const MAIN_BUTTON = 0;
 const LINK_BUTTON = 1;
@@ -414,12 +415,15 @@ export const openLinkOverlay = ({ cell, langtag, actions }) => {
     ? TaxonomyLinkOverlay.Header
     : LinkOverlayHeader;
   const Body = isTaxonomyLink ? TaxonomyLinkOverlay.Body : ReduxLinkOverlay;
+  const overlayClass = buildClassName("link-overlay", {
+    taxonomy: isTaxonomyLink
+  });
 
   actions.openOverlay({
     head: <Header langtag={langtag} cell={cell} title={cell} />,
     body: <Body cell={cell} langtag={langtag} />,
     type: "full-height",
-    classes: "link-overlay",
+    classes: overlayClass,
     title: cell,
     filterMode: FilterModes.CONTAINS,
     unlinkedOrder: 1

--- a/src/app/components/cells/link/LinkOverlay.jsx
+++ b/src/app/components/cells/link/LinkOverlay.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react";
 import * as Sentry from "@sentry/browser";
 import * as f from "lodash/fp";
 import i18n from "i18next";
+import TaxonomyLinkOverlay from "../../taxonomy/TaxonomyLinkOverlay";
 
 import { Directions, FilterModes } from "../../../constants/TableauxConstants";
 import {
@@ -24,6 +25,8 @@ import KeyboardShortcutsHelper from "../../../helpers/KeyboardShortcutsHelper";
 import LinkItem from "./LinkItem";
 import LinkOverlayHeader from "./LinkOverlayHeader";
 import withCachedLinks from "./LinkOverlayCache.jsx";
+import { isTaxonomyTable } from "../../taxonomy/taxonomy";
+import store from "../../../redux/store";
 
 const MAIN_BUTTON = 0;
 const LINK_BUTTON = 1;
@@ -400,11 +403,21 @@ class LinkOverlay extends PureComponent {
 
 export const openLinkOverlay = ({ cell, langtag, actions }) => {
   const ReduxLinkOverlay = withCachedLinks(LinkOverlay);
-  const overlayContent = <ReduxLinkOverlay cell={cell} langtag={langtag} />;
+  const linkTargetTableId = cell.column.toTable;
+  const linkTargetTable = f.prop(
+    ["tables", "data", linkTargetTableId],
+    store.getState()
+  );
+
+  const isTaxonomyLink = isTaxonomyTable(linkTargetTable);
+  const Header = isTaxonomyLink
+    ? TaxonomyLinkOverlay.Header
+    : LinkOverlayHeader;
+  const Body = isTaxonomyLink ? TaxonomyLinkOverlay.Body : ReduxLinkOverlay;
 
   actions.openOverlay({
-    head: <LinkOverlayHeader langtag={langtag} cell={cell} title={cell} />,
-    body: overlayContent,
+    head: <Header langtag={langtag} cell={cell} title={cell} />,
+    body: <Body cell={cell} langtag={langtag} />,
     type: "full-height",
     classes: "link-overlay",
     title: cell,

--- a/src/app/components/cells/link/LinkOverlay.jsx
+++ b/src/app/components/cells/link/LinkOverlay.jsx
@@ -28,7 +28,6 @@ import withCachedLinks from "./LinkOverlayCache.jsx";
 import { isTaxonomyTable } from "../../taxonomy/taxonomy";
 import store from "../../../redux/store";
 import { buildClassName } from "../../../helpers/buildClassName";
-h;
 const MAIN_BUTTON = 0;
 const LINK_BUTTON = 1;
 const LINKED_ITEMS = 0;

--- a/src/app/components/cells/link/LinkOverlay.jsx
+++ b/src/app/components/cells/link/LinkOverlay.jsx
@@ -28,7 +28,7 @@ import withCachedLinks from "./LinkOverlayCache.jsx";
 import { isTaxonomyTable } from "../../taxonomy/taxonomy";
 import store from "../../../redux/store";
 import { buildClassName } from "../../../helpers/buildClassName";
-
+h;
 const MAIN_BUTTON = 0;
 const LINK_BUTTON = 1;
 const LINKED_ITEMS = 0;

--- a/src/app/components/entityView/RowView.jsx
+++ b/src/app/components/entityView/RowView.jsx
@@ -23,6 +23,7 @@ import ShortTextView from "./text/ShortTextView";
 import TextView from "./text/TextView";
 import StatusView from "./status/StatusView";
 import { getCountryOfLangtag } from "../../helpers/multiLanguage";
+import Spinner from "../header/Spinner";
 
 class View extends PureComponent {
   static propTypes = {
@@ -87,6 +88,13 @@ class View extends PureComponent {
       hasFocusedChild,
       lockStatus
     } = this.props;
+
+    if (!cell || !cell.column) {
+      // This can happen when a request to load columns initially resets the
+      // column for the fraction of a second
+      return <Spinner />;
+    }
+
     const { kind, column } = cell;
     const views = {
       [ColumnKinds.link]: LinkView,

--- a/src/app/components/header/NavigationPopup.jsx
+++ b/src/app/components/header/NavigationPopup.jsx
@@ -47,6 +47,16 @@ const NavigationPopup = props => {
 
         <li className="main-navigation__entry">
           <Link
+            to={"/" + langtag + "/taxonomies"}
+            className="main-navigation__entry-button"
+          >
+            <SvgIcon icon="addSubItem" />
+            {t("header:menu.taxonomies")}
+          </Link>
+        </li>
+
+        <li className="main-navigation__entry">
+          <Link
             to={"/" + langtag + "/media"}
             className="main-navigation__entry-button"
           >

--- a/src/app/components/header/NavigationPopup.jsx
+++ b/src/app/components/header/NavigationPopup.jsx
@@ -50,7 +50,9 @@ const NavigationPopup = props => {
             to={"/" + langtag + "/taxonomies"}
             className="main-navigation__entry-button"
           >
-            <SvgIcon icon="addSubItem" />
+            <div className="service-icon">
+              <SvgIcon icon="addSubItem" />
+            </div>
             {t("header:menu.taxonomies")}
           </Link>
         </li>

--- a/src/app/components/header/tableSwitcher/TableSwitcher.jsx
+++ b/src/app/components/header/tableSwitcher/TableSwitcher.jsx
@@ -1,13 +1,13 @@
-import { translate } from "react-i18next";
-import React from "react";
-import f from "lodash/fp";
-import TableauxConstants from "../../../constants/TableauxConstants";
-import TableSwitcherPopup from "./TableSwitcherPopup";
 import classNames from "classnames";
+import f from "lodash/fp";
 import PropTypes from "prop-types";
-
-import { getTableDisplayName } from "../../../helpers/multiLanguage";
+import React from "react";
+import { translate } from "react-i18next";
+import TableauxConstants from "../../../constants/TableauxConstants";
 import { memoizeOne } from "../../../helpers/functools.js";
+import { getTableDisplayName } from "../../../helpers/multiLanguage";
+import { isTaxonomyTable } from "../../taxonomy/taxonomy";
+import TableSwitcherPopup from "./TableSwitcherPopup";
 
 const sortTables = memoizeOne((langtag, tables, getDisplayName) =>
   f.compose(
@@ -47,7 +47,14 @@ class TableSwitcherButton extends React.PureComponent {
   };
 
   renderPopup = () => {
-    const { t, langtag, tables, currentTable, navigate } = this.props;
+    const {
+      t,
+      langtag,
+      tables: allTables,
+      currentTable,
+      navigate
+    } = this.props;
+    const tables = f.reject(isTaxonomyTable, allTables);
 
     const groups = f.flow(
       f.reject("hidden"), //   ...of visible tables

--- a/src/app/components/helperComponents/SvgIcon.jsx
+++ b/src/app/components/helperComponents/SvgIcon.jsx
@@ -19,6 +19,7 @@ import PropTypes from "prop-types";
 import { makeRequest } from "../../helpers/apiHelper";
 
 const iconUrls = {
+  addSubItem: "/img/icons/add-sub-item.svg",
   arrow: "/img/icons/arrow-long.svg",
   burger: "/img/icons/burger-thin.svg",
   check: "/img/icons/check.svg",

--- a/src/app/components/overlay/EntityView/ForeignEntityView.jsx
+++ b/src/app/components/overlay/EntityView/ForeignEntityView.jsx
@@ -33,7 +33,7 @@ export class ForeignEntityViewBody extends PureComponent {
         .map(([column, value]) => getDisplayValue(column, value));
 
       // generate cell object
-      const titleSpec = {
+      const cell = {
         row,
         column: f.first(columns),
         table: grudData.tables.data[tableId]
@@ -53,12 +53,12 @@ export class ForeignEntityViewBody extends PureComponent {
       // set retrieved values as overlay props so we can fallback to
       // default entity view
       actions.setOverlayState({
-        title: titleSpec,
-        cell: titleSpec,
+        title: cell,
+        cell,
         id,
         columns,
         row,
-        table: titleSpec.table,
+        table: cell.table,
         loading: false
       });
     } catch (err) {

--- a/src/app/components/overlay/OverlayHeadRowIdentificator.jsx
+++ b/src/app/components/overlay/OverlayHeadRowIdentificator.jsx
@@ -71,14 +71,14 @@ const setupIdProps = withProps(({ cell, title, langtag }) => {
     column.kind === ColumnKinds.concat
       ? null
       : getColumnDisplayName(cellOrTitle.column, langtag);
-  const firstColumn = f.prop(["columns", table.id, "data", 0], state);
+  const firstColumnId = f.prop(["columns", table.id, "data", 0, "id"], state);
   const liveRow = doto(
     state,
     f.prop(["rows", table.id, "data"]),
     f.find(f.propEq("id", row.id))
   );
 
-  return firstColumn.id === column.id
+  return firstColumnId === column.id
     ? {
         cell: cellOrTitle,
         columnDisplayName

--- a/src/app/components/overlay/SelectLinkTargetOverlay.jsx
+++ b/src/app/components/overlay/SelectLinkTargetOverlay.jsx
@@ -22,6 +22,7 @@ import { SwitchSortingButton } from "../cells/link/LinkOverlayFragments";
 import OverlayHeadRowIdentificator from "../overlay/OverlayHeadRowIdentificator";
 import * as tax from "../taxonomy/taxonomy";
 import TaxonomySelectLinkTargetOverlay from "../taxonomy/TaxonomySelectLinkTargetOverlay";
+import getDisplayValue from "../../helpers/getDisplayValue";
 
 const ListItem = ({ isLinked, item, onChange, onEdit, style, langtag }) => {
   const displayValue = unless(
@@ -321,7 +322,17 @@ export const openSelectLinkTargetOverlay = ({
 
   store.dispatch(
     actions.openOverlay({
-      head: <Head cell={cell} langtag={langtag} />,
+      head: (
+        <Head
+          title={retrieveTranslation(
+            langtag,
+            getDisplayValue(cell.column, cell.value)
+          )}
+          cell={cell}
+          langtag={langtag}
+          context={i18n.t("table:select-link-target.context")}
+        />
+      ),
       body: (
         <Body
           oldRowId={row.id}

--- a/src/app/components/overlay/SelectLinkTargetOverlay.jsx
+++ b/src/app/components/overlay/SelectLinkTargetOverlay.jsx
@@ -20,6 +20,8 @@ import { addEmptyRow } from "../../redux/actions/rowActions";
 import { openEntityView } from "./EntityViewOverlay";
 import { SwitchSortingButton } from "../cells/link/LinkOverlayFragments";
 import OverlayHeadRowIdentificator from "../overlay/OverlayHeadRowIdentificator";
+import * as tax from "../taxonomy/taxonomy";
+import TaxonomySelectLinkTargetOverlay from "../taxonomy/TaxonomySelectLinkTargetOverlay";
 
 const ListItem = ({ isLinked, item, onChange, onEdit, style, langtag }) => {
   const displayValue = unless(
@@ -304,12 +306,24 @@ export const openSelectLinkTargetOverlay = ({
   selectedTargetRowId // optional, when re-selecting
 }) => {
   const cell = { ...row.cells[0], value: row.values[0] };
+  const isTaxonomyTable = tax.isTaxonomyTable(cell.table);
+
+  const Head = isTaxonomyTable
+    ? TaxonomySelectLinkTargetOverlay.Head
+    : SelectLinkTargetOverlayHeader;
+  const Body = isTaxonomyTable
+    ? TaxonomySelectLinkTargetOverlay.Body
+    : SelectLinkTargetOverlay;
+
+  const cssClass = buildClassName("select-link-target-overlay", {
+    taxonomy: isTaxonomyTable
+  });
 
   store.dispatch(
     actions.openOverlay({
-      head: <SelectLinkTargetOverlayHeader cell={cell} langtag={langtag} />,
+      head: <Head cell={cell} langtag={langtag} />,
       body: (
-        <SelectLinkTargetOverlay
+        <Body
           oldRowId={row.id}
           tableId={table.id}
           onSubmit={onSubmit}
@@ -318,7 +332,7 @@ export const openSelectLinkTargetOverlay = ({
         />
       ),
       type: "full-height",
-      classes: "select-link-target-overlay"
+      classes: cssClass
     })
   );
 };

--- a/src/app/components/table/Table.jsx
+++ b/src/app/components/table/Table.jsx
@@ -16,6 +16,7 @@ import RowContextMenu from "../contextMenu/RowContextMenu";
 import VirtualTable from "./VirtualTable";
 import { isTaxonomyTable } from "../taxonomy/taxonomy";
 import TaxonomyTable from "../taxonomy/TaxonomyTable";
+import { buildClassName } from "../../helpers/buildClassName";
 
 class Table extends PureComponent {
   /**
@@ -156,13 +157,21 @@ class Table extends PureComponent {
       f.map("values")
     );
 
+    const isTaxonomy = table && isTaxonomyTable(table);
+    const isSettings = table && table.type === "settings";
+    const tableClass = buildClassName("tableaux-table", {
+      taxonomy: isTaxonomy,
+      settings: isSettings,
+      generic: !isTaxonomy && !isSettings
+    });
+
     return (
       <section
         id="table-wrapper"
         tabIndex="-1"
         onMouseDown={this.onMouseDownHandler}
       >
-        <div className="tableaux-table">
+        <div className={tableClass}>
           {isTaxonomyTable(table) ? (
             <TaxonomyTable tableId={table.id} langtag={langtag} />
           ) : (

--- a/src/app/components/tableView/TableView.jsx
+++ b/src/app/components/tableView/TableView.jsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from "react";
 import f from "lodash/fp";
 import i18n from "i18next";
 import { branch, renderComponent } from "recompose";
+import { isTaxonomyTable } from "../taxonomy/taxonomy";
 
 import PropTypes from "prop-types";
 
@@ -266,48 +267,58 @@ class TableView extends PureComponent {
           handleLanguageSwitch={this.onLanguageSwitch}
           pageTitleOrKey="pageTitle.tables"
         >
-          <TableSwitcher
-            langtag={langtag}
-            currentTable={table}
-            tables={tables}
-            navigate={this.onNavigate}
-          />
-          <TableSettings langtag={langtag} table={table} actions={actions} />
-          <Filter
-            langtag={langtag}
-            table={table}
-            columns={[RowIdColumn, ...columns]}
-            currentFilter={{
-              filters: this.props.tableView.filters,
-              sorting: this.props.tableView.sorting
-            }}
-            setRowFilter={this.props.actions.setFiltersAndSorting}
-            actions={actions}
-          />
-          {table && columns && columns.length > 1 ? (
-            <ColumnFilter
-              langtag={langtag}
-              columns={columns}
-              tableId={tableId}
-              columnActions={columnActions}
-              columnOrdering={columnOrdering}
-            />
+          {isTaxonomyTable(table) ? (
+            <div className="hfill" />
           ) : (
-            <div />
+            <>
+              <TableSwitcher
+                langtag={langtag}
+                currentTable={table}
+                tables={tables}
+                navigate={this.onNavigate}
+              />
+              <TableSettings
+                langtag={langtag}
+                table={table}
+                actions={actions}
+              />
+              <Filter
+                langtag={langtag}
+                table={table}
+                columns={[RowIdColumn, ...columns]}
+                currentFilter={{
+                  filters: this.props.tableView.filters,
+                  sorting: this.props.tableView.sorting
+                }}
+                setRowFilter={this.props.actions.setFiltersAndSorting}
+                actions={actions}
+              />
+              {table && columns && columns.length > 1 ? (
+                <ColumnFilter
+                  langtag={langtag}
+                  columns={columns}
+                  tableId={tableId}
+                  columnActions={columnActions}
+                  columnOrdering={columnOrdering}
+                />
+              ) : (
+                <div />
+              )}
+              <HistoryButtons
+                tableId={tableId}
+                actions={actions}
+                tableView={tableView}
+              />
+              <div className="header-separator" />
+              <Spinner isLoading={f.isEmpty(allDisplayValues)} />
+              <PasteCellIcon
+                clearCellClipboard={this.clearCellClipboard}
+                pasteOriginCell={pasteOriginCell}
+                pasteOriginCellLang={pasteOriginCellLang}
+                tableId={table.id}
+              />
+            </>
           )}
-          <HistoryButtons
-            tableId={tableId}
-            actions={actions}
-            tableView={tableView}
-          />
-          <div className="header-separator" />
-          <Spinner isLoading={f.isEmpty(allDisplayValues)} />
-          <PasteCellIcon
-            clearCellClipboard={this.clearCellClipboard}
-            pasteOriginCell={pasteOriginCell}
-            pasteOriginCellLang={pasteOriginCellLang}
-            tableId={table.id}
-          />
         </GrudHeader>
         {this.renderTableOrSpinner()}
         <JumpSpinner isOpen={!!this.props.showCellJumpOverlay && !filtering} />

--- a/src/app/components/taxonomy/TaxonomyDashboard.jsx
+++ b/src/app/components/taxonomy/TaxonomyDashboard.jsx
@@ -1,0 +1,73 @@
+import i18n from "i18next";
+import f from "lodash/fp";
+import React, { useCallback } from "react";
+import { useSelector } from "react-redux";
+import {
+  getTableDisplayName,
+  retrieveTranslation
+} from "../../helpers/multiLanguage";
+import GrudHeader from "../GrudHeader";
+import { switchLanguageHandler } from "../Router";
+import * as t from "./taxonomy";
+import route from "../../helpers/apiRoutes";
+import { Link } from "react-router-dom";
+
+const TaxonomyTableCard = ({ table, langtag }) => (
+  <div className="card">
+    <header className="card__header">
+      <h1 className="card__header-title">
+        {getTableDisplayName(table, langtag)}
+      </h1>{" "}
+    </header>
+    <section className="card__content">
+      <div>{retrieveTranslation(langtag, table.description)}</div>
+    </section>
+    <footer className="card__footer">
+      <Link to={route.toTable({ tableId: table.id })}>
+        <button className="button default">{i18n.t("common:open")}</button>
+      </Link>
+    </footer>
+  </div>
+);
+
+const selectTaxonomyTables = f.compose(
+  f.filter(t.isTaxonomyTable),
+  f.propOr([], "tables.data")
+);
+
+const TaxonomyDashboard = props => {
+  const { langtag } = props;
+  const tables_ = useSelector(selectTaxonomyTables);
+  const tables = Array(12).fill(tables_[0]);
+  const handleSwitchLangtag = useCallback(newLangtag => {
+    switchLanguageHandler(history, newLangtag);
+  });
+  return (
+    <div className="taxonomy-dashboard">
+      <GrudHeader
+        pageTitleOrKey={i18n.t("table:taxonomy.title")}
+        langtag={langtag}
+        handleLanguageSwitch={handleSwitchLangtag}
+      />
+      <main className="taxonomy-dashboard__content-wrapper">
+        <section className="taxonomy-dashboard__header">
+          <h1 className="taxonomy-dashboard__header-title">
+            {i18n.t("table:taxonomy.title")}
+          </h1>
+        </section>
+        <section className="taxonomy-dashboard__content">
+          {tables.map(table => (
+            <TaxonomyTableCard
+              key={table.name}
+              table={table}
+              langtag={langtag}
+            />
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+TaxonomyDashboard.displayName = "TaxonomyDashboard";
+export default TaxonomyDashboard;

--- a/src/app/components/taxonomy/TaxonomyDashboard.jsx
+++ b/src/app/components/taxonomy/TaxonomyDashboard.jsx
@@ -10,7 +10,7 @@ import GrudHeader from "../GrudHeader";
 import { switchLanguageHandler } from "../Router";
 import * as t from "./taxonomy";
 import route from "../../helpers/apiRoutes";
-import { Link } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 
 const TaxonomyTableCard = ({ table, langtag }) => (
   <div className="card">
@@ -36,7 +36,7 @@ const selectTaxonomyTables = f.compose(
 );
 
 const TaxonomyDashboard = props => {
-  const { langtag } = props;
+  const { history, langtag } = props;
   const tables = useSelector(selectTaxonomyTables);
   const handleSwitchLangtag = useCallback(newLangtag => {
     switchLanguageHandler(history, newLangtag);
@@ -69,4 +69,4 @@ const TaxonomyDashboard = props => {
 };
 
 TaxonomyDashboard.displayName = "TaxonomyDashboard";
-export default TaxonomyDashboard;
+export default withRouter(TaxonomyDashboard);

--- a/src/app/components/taxonomy/TaxonomyDashboard.jsx
+++ b/src/app/components/taxonomy/TaxonomyDashboard.jsx
@@ -37,8 +37,7 @@ const selectTaxonomyTables = f.compose(
 
 const TaxonomyDashboard = props => {
   const { langtag } = props;
-  const tables_ = useSelector(selectTaxonomyTables);
-  const tables = Array(12).fill(tables_[0]);
+  const tables = useSelector(selectTaxonomyTables);
   const handleSwitchLangtag = useCallback(newLangtag => {
     switchLanguageHandler(history, newLangtag);
   });

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -13,6 +13,7 @@ import Spinner from "../header/Spinner";
 import * as t from "./taxonomy";
 import TreeView from "./TreeView";
 import Header from "../overlay/Header";
+import { intersperse } from "../../helpers/functools";
 
 // NodeActionButton :
 //   { onClick : (TreeNode -> ())
@@ -34,16 +35,39 @@ const mkNodeActionButton = ({ onClick, icon, idsToDisable }) => ({ node }) => {
   );
 };
 
-const LinkedItem = ({ node, langtag, ActionButton }) => (
-  <li className="linked-item">
-    <ActionButton node={node} />
-    <div className="linked-item__content">
-      <span className="linked-item__content-title">
-        {retrieveTranslation(langtag, node.displayValue)}
-      </span>
-    </div>
-  </li>
-);
+const LinkedItem = ({ node, langtag, ActionButton, path }) => {
+  const PathSeparator = (
+    <span className="linked-item__path-separator">&gt;</span>
+  );
+
+  return (
+    <li className="linked-item">
+      <ActionButton node={node} />
+      <div className="linked-item__content">
+        <div className="linked-item__path">
+          {intersperse(
+            PathSeparator,
+            f.map(n => {
+              const title = retrieveTranslation(langtag, n.displayValue);
+              return (
+                <span
+                  key={n.id}
+                  className="linked-item__path-step"
+                  title={title}
+                >
+                  {title}
+                </span>
+              );
+            }, path)
+          )}
+        </div>
+        <span className="linked-item__content-title">
+          {retrieveTranslation(langtag, node.displayValue)}
+        </span>
+      </div>
+    </li>
+  );
+};
 
 const CardinalityInfo = ({ nLinked, limit }) => {
   const parts = i18n.t("table:link-overlay-count").split("|");
@@ -109,6 +133,7 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
                   key={node.id}
                   node={node}
                   langtag={langtag}
+                  path={t.getPathToNode(nodes)(node)}
                   ActionButton={mkNodeActionButton({
                     onClick: onUnlinkNode,
                     icon: "fa-minus"

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -1,0 +1,88 @@
+import f from "lodash/fp";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import actionCreator from "../../redux/actionCreators";
+import Spinner from "../header/Spinner";
+import * as t from "./taxonomy";
+import TreeView from "./TreeView";
+
+const TaxonomyLinkOverlayBody = ({ cell, langtag, nodes }) => {
+  return (
+    <>
+      <section className="taxonomy-link-overlay overlay-subheader">
+        <h1 className="overlay-subheader__title">Select stuff</h1>
+        <div className="overlay-subheader__description">I am content</div>
+      </section>
+      <section className="taxonomy-link-overlay overlay-main-content">
+        <TreeView nodes={nodes} langtag={langtag} shouldShowAction={f.F} />;
+      </section>
+    </>
+  );
+};
+
+const StateTag = {
+  loading: "loading",
+  error: "error",
+  done: "done"
+};
+const State = (tag, data) => ({ tag, data });
+const toState = ({ error, finishedLoading, data } = {}) =>
+  error
+    ? State(StateTag.error)
+    : finishedLoading
+    ? State(StateTag.done, data)
+    : State(StateTag.loading);
+const combineStates = (...states) => {
+  return f.cond([
+    [f.some(isError), () => State(StateTag.error)],
+    [f.every(isDone), () => State(StateTag.done, f.last(states).data)],
+    [() => true, () => State(StateTag.loading)]
+  ])(states);
+};
+const isLoading = state => state.tag === StateTag.loading;
+const isDone = state => state.tag === StateTag.done;
+const isError = state => state.tag === StateTag.error;
+const storeToState = path =>
+  f.compose(
+    toState,
+    f.prop(path)
+  );
+
+const DataLoader = props => {
+  const { cell } = props;
+  const dispatch = useDispatch();
+  const tableId = cell.column.toTable;
+
+  const columnState = useSelector(storeToState(["columns", tableId]));
+  const rowState = useSelector(storeToState(["rows", tableId]));
+
+  useEffect(() => {
+    if (!f.isNil(tableId)) dispatch(actionCreator.loadColumns(tableId));
+  }, [tableId]);
+  useEffect(() => {
+    if (isDone(columnState) && !isDone(rowState))
+      dispatch(actionCreator.loadAllRows(tableId));
+  }, [tableId, columnState.tag]);
+
+  const componentState = combineStates(columnState, rowState);
+
+  return isLoading(componentState) ? (
+    <Spinner />
+  ) : isDone(componentState) ? (
+    <TaxonomyLinkOverlayBody
+      {...props}
+      nodes={t.tableToTreeNodes({ rows: componentState.data })}
+    />
+  ) : (
+    <div>Just. No.</div>
+  );
+};
+
+const TaxonomyLinkOverlayHeader = ({ cell, langtag, title }) => (
+  <div>Taxonomy link header</div>
+);
+
+export default {
+  Header: TaxonomyLinkOverlayHeader,
+  Body: DataLoader
+};

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -73,12 +73,16 @@ const LinkedItem = ({ node, langtag, ActionButton, path, onFocusNode }) => {
 const CardinalityInfo = ({ nLinked, limit }) => {
   const parts = i18n.t("table:link-overlay-count").split("|");
   return (
-    /*!limit ? null : */ <p className="cardinality-count">
-      <span className="text">{parts[0]}</span>
-      <span className="number">{nLinked}</span>
-      <span className="text">{parts[1]}</span>
-      <span className="number">{limit || "∞"}</span>
-      <span className="text">{parts[2]}</span>
+    <p className="cardinality-count">
+      {!limit ? null : (
+        <>
+          <span className="text">{parts[0]}</span>
+          <span className="number">{nLinked}</span>
+          <span className="text">{parts[1]}</span>
+          <span className="number">{limit}</span>
+          <span className="text">{parts[2]}</span>
+        </>
+      )}
     </p>
   );
 };

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -1,6 +1,6 @@
 import i18n from "i18next";
 import f from "lodash/fp";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { buildClassName } from "../../helpers/buildClassName";
 import {
@@ -14,6 +14,9 @@ import * as t from "./taxonomy";
 import TreeView from "./TreeView";
 import Header from "../overlay/Header";
 import { intersperse } from "../../helpers/functools";
+import TaxonomySearch from "./TaxonomySearch";
+
+const EXPANDED_NODE_KEY = "expandedNode";
 
 // NodeActionButton :
 //   { onClick : (TreeNode -> ())
@@ -87,7 +90,13 @@ const CardinalityInfo = ({ nLinked, limit }) => {
   );
 };
 
-const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
+const TaxonomyLinkOverlayBody = ({
+  actions,
+  cell,
+  langtag,
+  nodes,
+  sharedData
+}) => {
   const setNodeIsLinked = (cell, shouldLink) => node => {
     const newValue = shouldLink
       ? [...cell.value, { id: node.id, value: node.displayValue }]
@@ -101,6 +110,15 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
   const onLinkNode = setNodeIsLinked(cell, true);
   const onUnlinkNode = setNodeIsLinked(cell, false);
   const [focusFX, setFocusFX] = useState(undefined);
+  useEffect(() => {
+    const nodeToExpand = f.prop(EXPANDED_NODE_KEY, sharedData);
+    if (nodeToExpand) {
+      setFocusFX(nodeToExpand);
+    }
+  }, [
+    !!f.prop(EXPANDED_NODE_KEY, sharedData),
+    f.prop([EXPANDED_NODE_KEY, "id"], sharedData)
+  ]);
   const shouldShowAction = ({ node, expandedNodeId }) =>
     t.isLeaf(node) &&
     (f.every(f.isNil, [node.parent, expandedNodeId]) ||
@@ -248,7 +266,7 @@ const DataLoader = props => {
 };
 
 const TaxonomyLinkOverlayHeader = props => {
-  const { cell } = props;
+  const { cell, langtag, updateSharedData } = props;
 
   const liveCell = useSelector(
     selectLiveCell({
@@ -258,13 +276,39 @@ const TaxonomyLinkOverlayHeader = props => {
     })
   );
 
+  const onSelectSearchResult = node =>
+    updateSharedData(f.assoc(EXPANDED_NODE_KEY, node));
+
+  const rows = useSelector(f.prop(["rows", cell.column.toTable, "data"]));
+  const nodes = useMemo(() => t.tableToTreeNodes({ rows }), [rows]);
+
   return (
     <Header
       {...props}
       cell={liveCell}
       context={i18n.t("table:taxonomy.link-category")}
-    />
+    >
+      <TaxonomySearch
+        langtag={langtag}
+        nodes={nodes}
+        onSelect={onSelectSearchResult}
+      />
+    </Header>
   );
+};
+
+export const openTaxonomyLinkOverlay = ({ cell, langtag, actions }) => {
+  const overlayClass = buildClassName("link-overlay", { taxonomy: true });
+
+  actions.openOverlay({
+    head: (
+      <TaxonomyLinkOverlayHeader langtag={langtag} cell={cell} title={cell} />
+    ),
+    body: <DataLoader cell={cell} langtag={langtag} />,
+    type: "full-height",
+    classes: overlayClass,
+    title: cell
+  });
 };
 
 export default {

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -37,7 +37,11 @@ const mkNodeActionButton = ({ onClick, icon, idsToDisable }) => ({ node }) => {
 const LinkedItem = ({ node, langtag, ActionButton }) => (
   <li className="linked-item">
     <ActionButton node={node} />
-    <div>{retrieveTranslation(langtag, node.displayValue)}</div>
+    <div className="linked-item__content">
+      <span className="linked-item__content-title">
+        {retrieveTranslation(langtag, node.displayValue)}
+      </span>
+    </div>
   </li>
 );
 

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -1,6 +1,6 @@
 import i18n from "i18next";
 import f from "lodash/fp";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { buildClassName } from "../../helpers/buildClassName";
 import {
@@ -35,7 +35,7 @@ const mkNodeActionButton = ({ onClick, icon, idsToDisable }) => ({ node }) => {
   );
 };
 
-const LinkedItem = ({ node, langtag, ActionButton, path }) => {
+const LinkedItem = ({ node, langtag, ActionButton, path, onFocusNode }) => {
   const PathSeparator = (
     <span className="linked-item__path-separator">&gt;</span>
   );
@@ -54,6 +54,7 @@ const LinkedItem = ({ node, langtag, ActionButton, path }) => {
                   key={n.id}
                   className="linked-item__path-step"
                   title={title}
+                  onClick={() => onFocusNode(n)}
                 >
                   {title}
                 </span>
@@ -95,6 +96,7 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
   const linkedIds = new Set(f.map("id", cell.value));
   const onLinkNode = setNodeIsLinked(cell, true);
   const onUnlinkNode = setNodeIsLinked(cell, false);
+  const [focusFX, setFocusFX] = useState(undefined);
   const shouldShowAction = ({ node, expandedNodeId }) =>
     t.isLeaf(node) &&
     (f.every(f.isNil, [node.parent, expandedNodeId]) ||
@@ -115,6 +117,10 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
     [() => true, () => new Set(f.map("id", nodes))]
   ])(cardinalityConstraint);
 
+  const handleFocusFX = useCallback(node => {
+    setFocusFX(node);
+  });
+
   return (
     <>
       <section className="taxonomy-link-overlay overlay-subheader">
@@ -134,6 +140,7 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
                   node={node}
                   langtag={langtag}
                   path={t.getPathToNode(nodes)(node)}
+                  onFocusNode={handleFocusFX}
                   ActionButton={mkNodeActionButton({
                     onClick: onUnlinkNode,
                     icon: "fa-minus"
@@ -146,6 +153,7 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
       </section>
       <section className="taxonomy-link-overlay overlay-main-content">
         <TreeView
+          focusNode={focusFX}
           nodes={nodes}
           langtag={langtag}
           shouldShowAction={shouldShowAction}

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -292,6 +292,7 @@ const TaxonomyLinkOverlayHeader = props => {
         langtag={langtag}
         nodes={nodes}
         onSelect={onSelectSearchResult}
+        classNames="filter-bar"
       />
     </Header>
   );

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -178,7 +178,7 @@ const DataLoader = props => {
   const liveCell = useSelector(
     selectLiveCell({
       columnId: cell.column.id,
-      rowId: cell.column.id,
+      rowId: cell.row.id,
       tableId: cell.table.id
     })
   );

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -90,7 +90,7 @@ const TaxonomyLinkOverlayBody = ({ actions, cell, langtag, nodes }) => {
   return (
     <>
       <section className="taxonomy-link-overlay overlay-subheader">
-        <h1 className="overlay-subheader__title">{headline}</h1>
+        <div className="overlay-subheader__title">{headline}</div>
         <div className="overlay-subheader__description">
           <CardinalityInfo
             nLinked={linkedCategories.length}

--- a/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomyLinkOverlay.jsx
@@ -227,7 +227,7 @@ const selectLiveCell = ({ tableId, columnId, rowId }) => store => {
   };
 };
 
-const DataLoader = props => {
+const DataLoader = Component => props => {
   const { cell } = props;
   const dispatch = useDispatch();
   const toTableId = cell.column.toTable;
@@ -252,10 +252,12 @@ const DataLoader = props => {
 
   const componentState = combineStates(columnState, rowState);
 
+  console.log({ rows: componentState.data });
+
   return isLoading(componentState) ? (
     <Spinner />
   ) : isDone(componentState) ? (
-    <TaxonomyLinkOverlayBody
+    <Component
       {...props}
       nodes={t.tableToTreeNodes({ rows: componentState.data })}
       cell={liveCell}
@@ -314,5 +316,7 @@ export const openTaxonomyLinkOverlay = ({ cell, langtag, actions }) => {
 
 export default {
   Header: TaxonomyLinkOverlayHeader,
-  Body: DataLoader
+  Body: DataLoader(TaxonomyLinkOverlayBody),
+  DataLoader,
+  LinkedItem
 };

--- a/src/app/components/taxonomy/TaxonomySearch.jsx
+++ b/src/app/components/taxonomy/TaxonomySearch.jsx
@@ -129,12 +129,16 @@ const TaxonomySearch = ({
     onSelect(node);
   };
 
+  const inputClass = buildClassName("taxonomy-search__input", {
+    placeholder: f.isEmpty(searchTerm)
+  });
+
   return (
     <div className={`taxonomy-search ${classNames || ""}`} ref={containerRef}>
       <div className="taxonomy-search__wrapper">
         <input
           onFocus={handleFocusInput}
-          className="taxonomy-search__input"
+          className={inputClass}
           type="text"
           value={searchTerm}
           placeholder={i18n.t("table:taxonomy.search-input-placeholder")}

--- a/src/app/components/taxonomy/TaxonomySearch.jsx
+++ b/src/app/components/taxonomy/TaxonomySearch.jsx
@@ -1,0 +1,112 @@
+import i18n from "i18next";
+import * as f from "lodash/fp";
+import React, { useCallback, useMemo, useState } from "react";
+import { FilterModes } from "../../constants/TableauxConstants";
+import { buildClassName } from "../../helpers/buildClassName";
+import { intersperse } from "../../helpers/functools";
+import { retrieveTranslation } from "../../helpers/multiLanguage";
+import { createTextFilter } from "../../helpers/searchFunctions";
+import * as t from "./taxonomy";
+
+const ResultItem = ({ langtag, node, onSelect }) => {
+  const Separator = (
+    <span className="taxonomy-search__result-item__path-separator">&gt;</span>
+  );
+  const path = intersperse(
+    Separator,
+    node.path.map(n => {
+      const title = retrieveTranslation(langtag, n.displayValue);
+      return (
+        <span
+          key={n.id}
+          className="taxonomy-search__result-item__path-step"
+          title={title}
+        >
+          {title}
+        </span>
+      );
+    })
+  );
+
+  const className = buildClassName("taxonomy-search__result-item", {
+    leaf: t.isLeaf(node)
+  });
+
+  return (
+    <li className={className} onClick={() => onSelect(node)}>
+      <div className="taxonomy-search__result-item__path">{path}</div>
+      <div className="taxonomy-search__result-item__content">
+        {retrieveTranslation(langtag, node.displayValue)}
+      </div>
+    </li>
+  );
+};
+
+const TaxonomySearch = ({
+  nodes, // List TreeNode
+  onSelect, // TreeNode -> ()
+  langtag
+}) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [showResults, setShowResults] = useState(false);
+  const searchMode = FilterModes.CONTAINS;
+  const searchFn = useCallback(createTextFilter(searchMode, searchTerm), [
+    searchTerm
+  ]);
+  const results = useMemo(() => t.findTreeNodes(langtag)(searchFn)(nodes), [
+    nodes,
+    searchFn
+  ]);
+
+  const handleFocusInput = useCallback(() => {
+    setShowResults(true);
+  }, []);
+  const handleBlurInput = () => {
+    setShowResults(false);
+  };
+  const handleKeyPress = useCallback(event => {
+    const key = event.key;
+
+    if (key === "Escape" && !f.isEmpty(searchTerm)) {
+      event.stopPropagation();
+      setSearchTerm("");
+    }
+  });
+  const handleInput = useCallback(event => {
+    setSearchTerm(event.target.value);
+  }, []);
+
+  return (
+    <div className="taxonomy-search">
+      <div className="taxonomy-search__wrapper">
+        <input
+          onFocus={handleFocusInput}
+          onBlur={handleBlurInput}
+          className="taxonomy-search__input"
+          type="text"
+          value={searchTerm}
+          placeholder={i18n.t("table:taxonomy.search-placeholder")}
+          onChange={handleInput}
+          onKeyDown={handleKeyPress}
+        />
+        <i className="fa fa-search" />
+      </div>
+      {showResults ? (
+        <div className="taxonomy-search__results">
+          <ul className="taxonomy-search__results-list">
+            {results.map(node => (
+              <ResultItem
+                key={node.id}
+                langtag={langtag}
+                onSelect={onSelect}
+                node={node}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default TaxonomySearch;

--- a/src/app/components/taxonomy/TaxonomySearch.jsx
+++ b/src/app/components/taxonomy/TaxonomySearch.jsx
@@ -51,8 +51,12 @@ const ResultItem = ({ langtag, node, onSelect }) => {
     leaf: t.isLeaf(node)
   });
 
+  const handleSelect = () => {
+    onSelect(t.isLeaf(node) ? { id: node.parent } : node);
+  };
+
   return (
-    <li className={className} onClick={() => onSelect(node)}>
+    <li className={className} onClick={handleSelect}>
       <div className="taxonomy-search__result-item__wrapper">
         <div className="taxonomy-search__result-item__path">{path}</div>
         <div className="taxonomy-search__result-item__content">

--- a/src/app/components/taxonomy/TaxonomySearch.jsx
+++ b/src/app/components/taxonomy/TaxonomySearch.jsx
@@ -15,6 +15,18 @@ import { createTextFilter } from "../../helpers/searchFunctions";
 import { outsideClickEffect } from "../../helpers/useOutsideClick";
 import * as t from "./taxonomy";
 
+const EmptyResultsPlaceholder = () => {
+  const classNames = buildClassName("taxonomy-search__result-item", {
+    placeholder: true
+  });
+
+  return (
+    <li className={classNames}>
+      <span>{i18n.t("table:taxonomy.search-no-results")}</span>
+    </li>
+  );
+};
+
 const ResultItem = ({ langtag, node, onSelect }) => {
   const Separator = (
     <span className="taxonomy-search__result-item__path-separator">&gt;</span>
@@ -41,11 +53,13 @@ const ResultItem = ({ langtag, node, onSelect }) => {
 
   return (
     <li className={className} onClick={() => onSelect(node)}>
-      <div className="taxonomy-search__result-item__path">{path}</div>
-      <div className="taxonomy-search__result-item__content">
-        <span className="taxonomy-search__result-item__title">
-          {retrieveTranslation(langtag, node.displayValue)}
-        </span>
+      <div className="taxonomy-search__result-item__wrapper">
+        <div className="taxonomy-search__result-item__path">{path}</div>
+        <div className="taxonomy-search__result-item__content">
+          <span className="taxonomy-search__result-item__title">
+            {retrieveTranslation(langtag, node.displayValue)}
+          </span>
+        </div>
       </div>
     </li>
   );
@@ -60,7 +74,8 @@ const extractDisplayValue = langtag => node =>
 const TaxonomySearch = ({
   nodes, // List TreeNode
   onSelect, // TreeNode -> ()
-  langtag
+  langtag,
+  classNames
 }) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [showResults, setShowResults] = useState(false);
@@ -111,14 +126,14 @@ const TaxonomySearch = ({
   };
 
   return (
-    <div className="taxonomy-search" ref={containerRef}>
+    <div className={`taxonomy-search ${classNames || ""}`} ref={containerRef}>
       <div className="taxonomy-search__wrapper">
         <input
           onFocus={handleFocusInput}
           className="taxonomy-search__input"
           type="text"
           value={searchTerm}
-          placeholder={i18n.t("table:taxonomy.search-placeholder")}
+          placeholder={i18n.t("table:taxonomy.search-input-placeholder")}
           onChange={handleInput}
           onKeyDown={handleKeyPress}
         />
@@ -127,14 +142,18 @@ const TaxonomySearch = ({
       {showResults ? (
         <div className="taxonomy-search__results">
           <ul className="taxonomy-search__results-list">
-            {results.map(node => (
-              <ResultItem
-                key={node.id}
-                langtag={langtag}
-                onSelect={handleSelect}
-                node={node}
-              />
-            ))}
+            {f.isEmpty(results) ? (
+              <EmptyResultsPlaceholder />
+            ) : (
+              results.map(node => (
+                <ResultItem
+                  key={node.id}
+                  langtag={langtag}
+                  onSelect={handleSelect}
+                  node={node}
+                />
+              ))
+            )}
           </ul>
         </div>
       ) : null}

--- a/src/app/components/taxonomy/TaxonomySelectLinkTargetOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomySelectLinkTargetOverlay.jsx
@@ -7,7 +7,9 @@ import TreeView from "./TreeView";
 import Header from "../overlay/Header";
 import { buildClassName } from "../../helpers/buildClassName";
 import i18n from "i18next";
+import TaxonomySearch from "./TaxonomySearch";
 
+const NODES_KEY = "nodes";
 const FOCUSED_NODE_KEY = "focused_node";
 const ButtonMode = {
   add: "add",
@@ -15,8 +17,23 @@ const ButtonMode = {
 };
 
 const SelectLinkTargetOverlayHeader = props => {
-  const { cell, langtag, sharedData, updateSharedData } = props;
-  return <Header {...props} />;
+  const { langtag, sharedData, updateSharedData } = props;
+  const nodes = f.propOr([], NODES_KEY, sharedData);
+
+  const onSelectSearchResult = useCallback(node => {
+    updateSharedData(f.assoc(FOCUSED_NODE_KEY, node));
+  });
+
+  return (
+    <Header {...props}>
+      <TaxonomySearch
+        langtag={langtag}
+        nodes={nodes}
+        onSelect={onSelectSearchResult}
+        classNames="filter-bar"
+      />
+    </Header>
+  );
 };
 
 const mkActionButton = ({ onSubmit, selectedRowId, buttonMode, oldRowId }) => ({
@@ -37,7 +54,6 @@ const mkActionButton = ({ onSubmit, selectedRowId, buttonMode, oldRowId }) => ({
 };
 
 const SelectLinkTargetOverlayBody = ({
-  actions,
   tableId,
   updateSharedData,
   sharedData,
@@ -57,11 +73,14 @@ const SelectLinkTargetOverlayBody = ({
 
   useEffect(() => {
     const nodeToFocus = f.get(FOCUSED_NODE_KEY, sharedData);
-    if (focusedNode) focusNodeFX(nodeToFocus);
+    if (nodeToFocus) focusNodeFX(nodeToFocus);
   }, [
     f.prop(FOCUSED_NODE_KEY, sharedData),
     f.prop([FOCUSED_NODE_KEY, "id"], sharedData)
   ]);
+  useEffect(() => {
+    updateSharedData(f.assoc(NODES_KEY, nodes));
+  }, [nodes]);
 
   const shouldShowAction = useCallback(
     ({ node, expandedNodeId }) =>
@@ -73,6 +92,7 @@ const SelectLinkTargetOverlayBody = ({
 
   const selectedNode = selectedRowId && nodes.find(n => n.id === selectedRowId);
 
+  console.log(focusedNode);
   return (
     <>
       <section className="overlay-subheader">

--- a/src/app/components/taxonomy/TaxonomySelectLinkTargetOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomySelectLinkTargetOverlay.jsx
@@ -1,0 +1,117 @@
+import f from "lodash/fp";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import * as t from "./taxonomy";
+import TLO from "./TaxonomyLinkOverlay";
+import TreeView from "./TreeView";
+import Header from "../overlay/Header";
+import { buildClassName } from "../../helpers/buildClassName";
+import i18n from "i18next";
+
+const FOCUSED_NODE_KEY = "focused_node";
+const ButtonMode = {
+  add: "add",
+  delete: "delete"
+};
+
+const SelectLinkTargetOverlayHeader = props => {
+  const { cell, langtag, sharedData, updateSharedData } = props;
+  return <Header {...props} />;
+};
+
+const mkActionButton = ({ onSubmit, selectedRowId, buttonMode, oldRowId }) => ({
+  node
+}) => {
+  const isAddButton = buttonMode === ButtonMode.add;
+  const disabled =
+    isAddButton && (node.id === selectedRowId || node.id === oldRowId);
+  const buttonClass = buildClassName("set-link-button", { disabled });
+  const iconClass = `fa fa-${buttonMode === ButtonMode.add ? "plus" : "minus"}`;
+  const handleClick = onSubmit(isAddButton ? node : { id: null });
+
+  return (
+    <button className={buttonClass} onClick={handleClick} disabled={disabled}>
+      <i className={iconClass} />
+    </button>
+  );
+};
+
+const SelectLinkTargetOverlayBody = ({
+  actions,
+  tableId,
+  updateSharedData,
+  sharedData,
+  oldRowId,
+  onSubmit,
+  langtag,
+  initialTargetRowId
+}) => {
+  const [focusedNode, focusNodeFX] = useState(undefined);
+  const rows = useSelector(f.prop(["rows", tableId, "data"]));
+  const nodes = useMemo(() => t.tableToTreeNodes({ rows }), [rows]);
+  const [selectedRowId, setSelectedRowId] = useState(initialTargetRowId);
+  const handleSelectNode = node => () => {
+    setSelectedRowId(node.id);
+    onSubmit(node.id);
+  };
+
+  useEffect(() => {
+    const nodeToFocus = f.get(FOCUSED_NODE_KEY, sharedData);
+    if (focusedNode) focusNodeFX(nodeToFocus);
+  }, [
+    f.prop(FOCUSED_NODE_KEY, sharedData),
+    f.prop([FOCUSED_NODE_KEY, "id"], sharedData)
+  ]);
+
+  const shouldShowAction = useCallback(
+    ({ node, expandedNodeId }) =>
+      t.isLeaf(node) &&
+      (f.every(f.isNil, [node.parent, expandedNodeId]) ||
+        node.parent === expandedNodeId),
+    []
+  );
+
+  const selectedNode = selectedRowId && nodes.find(n => n.id === selectedRowId);
+
+  return (
+    <>
+      <section className="overlay-subheader">
+        <div className="overlay-subheader__title"></div>
+        <div className="overlay-subheader__description">
+          {f.isNil(selectedRowId) ? (
+            <span>{i18n.t("table:link-overlay-empty")}</span>
+          ) : (
+            <TLO.LinkedItem
+              node={selectedNode}
+              langtag={langtag}
+              ActionButton={mkActionButton({
+                selectedRowId,
+                buttonMode: ButtonMode.delete,
+                onSubmit: handleSelectNode
+              })}
+            />
+          )}
+        </div>
+      </section>
+      <section className="overlay-main-content">
+        <TreeView
+          langtag={langtag}
+          nodes={nodes}
+          focusNode={focusedNode}
+          NodeActionItem={mkActionButton({
+            selectedRowId,
+            buttonMode: ButtonMode.add,
+            onSubmit: handleSelectNode,
+            oldRowId
+          })}
+          shouldShowAction={shouldShowAction}
+        />
+      </section>
+    </>
+  );
+};
+
+export default {
+  Head: SelectLinkTargetOverlayHeader,
+  Body: SelectLinkTargetOverlayBody
+};

--- a/src/app/components/taxonomy/TaxonomySelectLinkTargetOverlay.jsx
+++ b/src/app/components/taxonomy/TaxonomySelectLinkTargetOverlay.jsx
@@ -8,6 +8,9 @@ import Header from "../overlay/Header";
 import { buildClassName } from "../../helpers/buildClassName";
 import i18n from "i18next";
 import TaxonomySearch from "./TaxonomySearch";
+import { forkJoin } from "../../helpers/functools";
+import getDisplayValue from "../../helpers/getDisplayValue";
+import { retrieveTranslation } from "../../helpers/multiLanguage";
 
 const NODES_KEY = "nodes";
 const FOCUSED_NODE_KEY = "focused_node";
@@ -71,6 +74,16 @@ const SelectLinkTargetOverlayBody = ({
     onSubmit(node.id);
   };
 
+  const recordDisplayValue = f.compose(
+    retrieveTranslation(langtag),
+    forkJoin(
+      getDisplayValue,
+      f.prop(["cells", 0, "column"]),
+      f.prop(["values", 0])
+    ),
+    f.find(f.propEq("id", oldRowId))
+  )(rows);
+
   useEffect(() => {
     const nodeToFocus = f.get(FOCUSED_NODE_KEY, sharedData);
     if (nodeToFocus) focusNodeFX(nodeToFocus);
@@ -92,11 +105,14 @@ const SelectLinkTargetOverlayBody = ({
 
   const selectedNode = selectedRowId && nodes.find(n => n.id === selectedRowId);
 
-  console.log(focusedNode);
   return (
     <>
       <section className="overlay-subheader">
-        <div className="overlay-subheader__title"></div>
+        <div className="overlay-subheader__title">
+          {i18n.t("table:select-link-target.title", {
+            linkTitle: recordDisplayValue
+          })}
+        </div>
         <div className="overlay-subheader__description">
           {f.isNil(selectedRowId) ? (
             <span>{i18n.t("table:link-overlay-empty")}</span>

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -15,6 +15,7 @@ import TreeView from "./TreeView";
 import { loadAndOpenEntityView } from "../overlay/EntityViewOverlay";
 import { rowValuesToCells } from "../../redux/reducers/rows";
 import { confirmDeleteRow } from "../overlay/ConfirmDependentOverlay";
+import { getTableDisplayName } from "../../helpers/multiLanguage";
 
 const shouldShowAction = ({ node, expandedNodeId }) =>
   (!node.parent && !expandedNodeId) || node.parent === expandedNodeId;
@@ -192,12 +193,19 @@ const TaxonomyTable = ({ langtag, tableId }) => {
   );
 
   return (
-    <TreeView
-      nodes={nodes}
-      langtag={langtag}
-      shouldShowAction={shouldShowAction}
-      NodeActionItem={TableEditor}
-    />
+    <>
+      <section className="table__subheader">
+        <h1 className="table__subheader-title">
+          {getTableDisplayName(table, langtag)}
+        </h1>
+      </section>
+      <TreeView
+        nodes={nodes}
+        langtag={langtag}
+        shouldShowAction={shouldShowAction}
+        NodeActionItem={TableEditor}
+      />
+    </>
   );
 };
 

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -4,11 +4,23 @@ import { useSelector } from "react-redux";
 import * as t from "./taxonomy";
 import TreeView from "./TreeView";
 
+const shouldShowAction = ({ node, expandedNodeId }) =>
+  (!node.parent && !expandedNodeId) || node.parent === expandedNodeId;
+
+const TableEditor = () => <span>X</span>;
+
 const TaxonomyTable = ({ langtag, tableId }) => {
   const rows = useSelector(f.propOr([], ["rows", tableId, "data"]));
   const nodes = t.tableToTreeNodes({ rows });
 
-  return <TreeView nodes={nodes} langtag={langtag} />;
+  return (
+    <TreeView
+      nodes={nodes}
+      langtag={langtag}
+      shouldShowAction={shouldShowAction}
+      NodeActionItem={TableEditor}
+    />
+  );
 };
 
 TaxonomyTable.displayName = "TaxonomyTable";

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -16,6 +16,7 @@ import { loadAndOpenEntityView } from "../overlay/EntityViewOverlay";
 import { rowValuesToCells } from "../../redux/reducers/rows";
 import { confirmDeleteRow } from "../overlay/ConfirmDependentOverlay";
 import { getTableDisplayName } from "../../helpers/multiLanguage";
+import TaxonomySearch from "./TaxonomySearch";
 
 const shouldShowAction = ({ node, expandedNodeId }) =>
   (!node.parent && !expandedNodeId) || node.parent === expandedNodeId;
@@ -192,19 +193,36 @@ const TaxonomyTable = ({ langtag, tableId }) => {
     [tableId, rows]
   );
 
+  const [nodeToFocus, focusNodeOnce] = useState(undefined);
+
+  const handleFocusSearchResult = node => {
+    console.log("handleFocusSearchResult", { node });
+    focusNodeOnce(node);
+  };
+
   return (
     <>
       <section className="table__subheader">
         <h1 className="table__subheader-title">
           {getTableDisplayName(table, langtag)}
         </h1>
+        <div className="taxonomy-table__search">
+          <TaxonomySearch
+            nodes={nodes}
+            langtag={langtag}
+            onSelect={handleFocusSearchResult}
+          />
+        </div>
       </section>
-      <TreeView
-        nodes={nodes}
-        langtag={langtag}
-        shouldShowAction={shouldShowAction}
-        NodeActionItem={TableEditor}
-      />
+      <section className="taxonomy-table__tree">
+        <TreeView
+          nodes={nodes}
+          langtag={langtag}
+          shouldShowAction={shouldShowAction}
+          NodeActionItem={TableEditor}
+          focusNode={nodeToFocus}
+        />
+      </section>
     </>
   );
 };

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -12,7 +12,7 @@ import action from "../../redux/actionCreators";
 import SvgIcon from "../helperComponents/SvgIcon";
 import * as t from "./taxonomy";
 import TreeView from "./TreeView";
-import { openEntityView } from "../overlay/EntityViewOverlay";
+import { loadAndOpenEntityView } from "../overlay/EntityViewOverlay";
 import { rowValuesToCells } from "../../redux/reducers/rows";
 import { confirmDeleteRow } from "../overlay/ConfirmDependentOverlay";
 
@@ -112,15 +112,15 @@ const mkTableEditor = entryGroups => ({ node }) => {
   );
 };
 
-const onCreateNode = ({ dispatch, table, columns }) => async ({
+const onCreateNode = ({ dispatch, table, columns, langtag }) => async ({
   tableId,
   parentNodeId
 }) => {
   const transformRows = rowValuesToCells(table, columns);
   const rows = await action
     .createAndLoadRow(dispatch, tableId, {
-      columns: [{ id: 4 }],
-      rows: [{ values: [parentNodeId || null] }]
+      columns: [{ id: 1 }, { id: 4 }],
+      rows: [{ values: [{ [langtag]: "" }, [parentNodeId || null]] }]
     })
     .then(transformRows);
 
@@ -142,11 +142,10 @@ const TaxonomyTable = ({ langtag, tableId }) => {
   const columns = useSelector(f.propOr([], ["columns", tableId, "data"]));
   const nodes = t.tableToTreeNodes({ rows, columns });
   const dispatch = useDispatch();
-  const createNewNode = onCreateNode({ dispatch, table, columns });
+  const createNewNode = onCreateNode({ dispatch, table, columns, langtag });
   const findRowById = rowId => rows.find(row => row.id === rowId);
   const editNode = node => {
-    const row = findRowById(node.id);
-    openEntityView({ langtag, table, row });
+    loadAndOpenEntityView({ langtag, tableId, rowId: node.id });
   };
   const addSiblingBelow = node => {
     createNewNode({ tableId, parentNodeId: node.parent }).then(editNode);

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -12,8 +12,9 @@ import action from "../../redux/actionCreators";
 import SvgIcon from "../helperComponents/SvgIcon";
 import * as t from "./taxonomy";
 import TreeView from "./TreeView";
-import { loadAndOpenEntityView } from "../overlay/EntityViewOverlay";
+import { openEntityView } from "../overlay/EntityViewOverlay";
 import { rowValuesToCells } from "../../redux/reducers/rows";
+import { confirmDeleteRow } from "../overlay/ConfirmDependentOverlay";
 
 const shouldShowAction = ({ node, expandedNodeId }) =>
   (!node.parent && !expandedNodeId) || node.parent === expandedNodeId;
@@ -142,8 +143,10 @@ const TaxonomyTable = ({ langtag, tableId }) => {
   const nodes = t.tableToTreeNodes({ rows, columns });
   const dispatch = useDispatch();
   const createNewNode = onCreateNode({ dispatch, table, columns });
+  const findRowById = rowId => rows.find(row => row.id === rowId);
   const editNode = node => {
-    loadAndOpenEntityView({ langtag, rowId: node.id, tableId });
+    const row = findRowById(node.id);
+    openEntityView({ langtag, table, row });
   };
   const addSiblingBelow = node => {
     createNewNode({ tableId, parentNodeId: node.parent }).then(editNode);
@@ -152,7 +155,8 @@ const TaxonomyTable = ({ langtag, tableId }) => {
     createNewNode({ tableId, parentNodeId: node.id }).then(editNode);
   };
   const deleteNode = node => {
-    dispatch(action.deleteRow({ tableId, rowId: node.id }));
+    const row = findRowById(node.id);
+    confirmDeleteRow({ row, table, langtag });
   };
 
   const TableEditor = useCallback(
@@ -185,7 +189,7 @@ const TaxonomyTable = ({ langtag, tableId }) => {
         }
       ]
     ]),
-    [tableId]
+    [tableId, rows]
   );
 
   return (

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -1,13 +1,122 @@
+import i18n from "i18next";
 import f from "lodash/fp";
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
+import { outsideClickEffect } from "../../helpers/useOutsideClick";
 import * as t from "./taxonomy";
 import TreeView from "./TreeView";
+import SvgIcon from "../helperComponents/SvgIcon";
+import { buildClassName } from "../../helpers/buildClassName";
 
 const shouldShowAction = ({ node, expandedNodeId }) =>
   (!node.parent && !expandedNodeId) || node.parent === expandedNodeId;
 
-const TableEditor = () => <span>X</span>;
+// EditorEntryDescription :
+//   { faIcon: String
+//   , titleKey: String
+//   , onClick: { node: TreeNode } => ()
+//   , isVisible: { node: TreeNode } => Boolean
+//   }
+
+// EditorEntry : { entry: EditorEntryDescription, node: TreeNode } -> React.Element
+const EditorEntry = ({ entry, node }) => (
+  <li
+    className="tree-node__menu-popup__item"
+    onClick={() => entry.onClick(node)}
+  >
+    <span className="item__icon">
+      <i className={`fa ${entry.faIcon}`} />
+    </span>
+    <span className="item-title">{i18n.t(entry.titleKey)}</span>
+  </li>
+);
+
+// EditorEntryGroup : { entries: List EditorEntryDescription, node: TreeNode } -> React.Element
+const EditorEntryGroup = ({ entries, node }) => (
+  <li className="tree-node__menu-popup__item-group">
+    <ul>
+      {entries.map((entry, idx) => (
+        <EditorEntry key={idx} entry={entry} node={node} />
+      ))}
+    </ul>
+  </li>
+);
+
+// mkTableEditor : List (List EditorEntryDescription) -> { node: TreeNode } -> React.Element
+const mkTableEditor = entryGroups => ({ node }) => {
+  const groups = entryGroups
+    .map(group =>
+      group.filter(
+        entry => !f.isFunction(entry.isVisible) || entry.isVisible(node)
+      )
+    )
+    .filter(group => !f.isEmpty(group));
+
+  const [isOpen, setIsOpen] = useState(false);
+  const handleTogglePopup = useCallback(
+    event => {
+      event.stopPropagation();
+      setIsOpen(!isOpen);
+    },
+    [isOpen]
+  );
+  const handleClosePopup = useCallback(() => setIsOpen(false), []);
+  const containerRef = useRef(null);
+
+  useEffect(
+    outsideClickEffect({
+      shouldListen: isOpen,
+      onOutsideClick: handleClosePopup,
+      containerRef
+    }),
+    [isOpen, containerRef.current]
+  );
+
+  const buttonClass = buildClassName("tree-node__menu-button", {
+    open: isOpen
+  });
+
+  return (
+    <button
+      className={buttonClass}
+      onClick={handleTogglePopup}
+      ref={containerRef}
+    >
+      <SvgIcon
+        containerClasses="tree-node__menu-button-icon"
+        icon="vdots"
+        center
+      />
+      {isOpen ? (
+        <div className="tree-node__menu-popup">
+          <ul className="tree--node__menu-popup__items-list">
+            {groups.map((entries, idx) => (
+              <EditorEntryGroup key={idx} entries={entries} node={node} />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </button>
+  );
+};
+
+const TableEditor = mkTableEditor([
+  [
+    {
+      faIcon: "fa-level-down flip-lr",
+      titleKey: "table:taxonomy.add-sibling-below"
+    },
+    { faIcon: "fa-level-up rotate-90", titleKey: "table:taxonomy.add-child" }
+  ],
+  [
+    { faIcon: "fa-pencil", titleKey: "table:taxonomy.edit" },
+    {
+      faIcon: "fa-trash",
+      titleKey: "table:taxonomy.delete",
+      isVisible: t.isLeaf
+    }
+  ]
+]);
 
 const TaxonomyTable = ({ langtag, tableId }) => {
   const rows = useSelector(f.propOr([], ["rows", tableId, "data"]));

--- a/src/app/components/taxonomy/TaxonomyTable.jsx
+++ b/src/app/components/taxonomy/TaxonomyTable.jsx
@@ -12,7 +12,7 @@ const shouldShowAction = ({ node, expandedNodeId }) =>
   (!node.parent && !expandedNodeId) || node.parent === expandedNodeId;
 
 // EditorEntryDescription :
-//   { faIcon: String
+//   { icon: String | React.Element
 //   , titleKey: String
 //   , onClick: { node: TreeNode } => ()
 //   , isVisible: { node: TreeNode } => Boolean
@@ -25,7 +25,11 @@ const EditorEntry = ({ entry, node }) => (
     onClick={() => entry.onClick(node)}
   >
     <span className="item__icon">
-      <i className={`fa ${entry.faIcon}`} />
+      {typeof entry.icon === "string" ? (
+        <i className={`fa ${entry.icon}`} />
+      ) : (
+        entry.icon || null
+      )}
     </span>
     <span className="item-title">{i18n.t(entry.titleKey)}</span>
   </li>
@@ -103,15 +107,18 @@ const mkTableEditor = entryGroups => ({ node }) => {
 const TableEditor = mkTableEditor([
   [
     {
-      faIcon: "fa-level-down flip-lr",
+      icon: "fa-level-down flip-lr",
       titleKey: "table:taxonomy.add-sibling-below"
     },
-    { faIcon: "fa-level-up rotate-90", titleKey: "table:taxonomy.add-child" }
+    {
+      icon: <SvgIcon icon="addSubItem" />,
+      titleKey: "table:taxonomy.add-child"
+    }
   ],
   [
-    { faIcon: "fa-pencil", titleKey: "table:taxonomy.edit" },
+    { icon: "fa-pencil", titleKey: "table:taxonomy.edit" },
     {
-      faIcon: "fa-trash",
+      icon: "fa-trash",
       titleKey: "table:taxonomy.delete",
       isVisible: t.isLeaf
     }

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -3,7 +3,16 @@ import { buildClassName } from "../../helpers/buildClassName";
 import { retrieveTranslation } from "../../helpers/multiLanguage";
 import { buildTree, isLeaf } from "./taxonomy";
 
-const ItemButton = ({ children, className, langtag, node, onClick }) => {
+const ItemButton = props => {
+  const {
+    children,
+    className,
+    langtag,
+    node,
+    onClick,
+    shouldShowAction = () => false,
+    NodeActionItem = () => null
+  } = props;
   const handleClick = () => {
     onClick && onClick(node);
   };
@@ -13,6 +22,8 @@ const ItemButton = ({ children, className, langtag, node, onClick }) => {
       className={`tree-node__item-button ${className || ""}`}
       onClick={handleClick}
     >
+      {shouldShowAction(props) ? <NodeActionItem {...props} /> : null}
+
       <span className="tree-node__name">
         {retrieveTranslation(langtag, node.displayValue)}
       </span>
@@ -30,7 +41,12 @@ const Node = props => {
 
   return (
     <>
-      <ItemButton langtag={langtag} node={node} onClick={onToggleExpand}>
+      <ItemButton
+        {...props}
+        langtag={langtag}
+        node={node}
+        onClick={onToggleExpand}
+      >
         <span className="tree-node__child-count">{childCount}</span>
         <span className="hfill" />
         <i className={"tree-node__toggle-indicator " + toggleIcon} />
@@ -48,15 +64,18 @@ const Node = props => {
 
 const Leaf = props => {
   const { onSelectLeaf, node, langtag } = props;
-  return <ItemButton onClick={onSelectLeaf} langtag={langtag} node={node} />;
+  return (
+    <ItemButton
+      {...props}
+      onClick={onSelectLeaf}
+      langtag={langtag}
+      node={node}
+    />
+  );
 };
 
 const TreeItem = props => {
-  const {
-    node,
-    NodeActionItem = () => null,
-    shouldShowAction = () => false
-  } = props;
+  const { node } = props;
   const Component = isLeaf(node) ? Leaf : Node;
   const cssClass = buildClassName("tree-node", {
     leaf: isLeaf(node),
@@ -65,7 +84,6 @@ const TreeItem = props => {
   });
   return (
     <li className={cssClass}>
-      {shouldShowAction(props) ? <NodeActionItem {...props} /> : null}
       <Component {...props} />
     </li>
   );

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -24,10 +24,12 @@ const ItemButton = props => {
     >
       {shouldShowAction(props) ? <NodeActionItem {...props} /> : null}
 
-      <span className="tree-node__name">
-        {retrieveTranslation(langtag, node.displayValue)}
-      </span>
-      {children}
+      <div className="tree-node__title">
+        <span className="tree-node__name">
+          {retrieveTranslation(langtag, node.displayValue)}
+        </span>
+        {children}
+      </div>
     </div>
   );
 };
@@ -80,7 +82,8 @@ const TreeItem = props => {
   const cssClass = buildClassName("tree-node", {
     leaf: isLeaf(node),
     "on-path": node.onPath,
-    expanded: node.expanded
+    expanded: node.expanded,
+    default: !node.onPath && !node.expanded
   });
   return (
     <li className={cssClass}>

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -121,6 +121,15 @@ const Leaf = props => {
 
 const TreeItem = props => {
   const { node } = props;
+  useEffect(() => {
+    if (node.expanded && nodeRef.current) {
+      setTimeout(
+        () => nodeRef.current.scrollIntoView({ behavior: "smooth" }),
+        getCssVarNumeric("--tree-animation-duration")
+      );
+    }
+  }, [node.id, node.expanded]);
+  const nodeRef = useRef();
   const Component = isLeaf(node) ? Leaf : Node;
   const cssClass = buildClassName("tree-node", {
     leaf: isLeaf(node),
@@ -129,7 +138,7 @@ const TreeItem = props => {
     default: (!node.onPath && !node.expanded) || isLeaf(node)
   });
   return (
-    <li className={cssClass}>
+    <li ref={nodeRef} className={cssClass}>
       <Component {...props} />
     </li>
   );

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -27,7 +27,7 @@ const ItemButton = props => {
 
       <div className="tree-node__title">
         <span className="tree-node__name">
-          {retrieveTranslation(langtag || "de-DE", node.displayValue)}
+          {retrieveTranslation(langtag, node.displayValue)}
         </span>
         {children}
       </div>
@@ -68,10 +68,8 @@ const AnimateChildNodes = props => {
 
   useEffect(() => {
     if (isInitial) {
-      console.log(node.id, "initial");
       setIsInitial(false);
     } else {
-      console.log(node.id, "=>", show);
       setEntering(show);
       setLeaving(!show);
     }

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -125,8 +125,8 @@ const TreeItem = props => {
   const cssClass = buildClassName("tree-node", {
     leaf: isLeaf(node),
     "on-path": node.onPath,
-    expanded: node.expanded,
-    default: !node.onPath && !node.expanded
+    expanded: node.expanded && !isLeaf(node),
+    default: (!node.onPath && !node.expanded) || isLeaf(node)
   });
   return (
     <li className={cssClass}>

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -140,7 +140,8 @@ const TreeView = ({
   nodes, // List TreeNode
   onSelectLeaf, // TreeNode -> Effect
   NodeActionItem, // { node : TreeNode, langtag : String } -> React.Element
-  shouldShowAction // { node : TreeNode, expandedNodeId : RowId } -> Boolean
+  shouldShowAction, // { node : TreeNode, expandedNodeId : RowId } -> Boolean
+  focusNode // TreeNode | undefined
 }) => {
   const [expandedNodeId, setExpandedNodeId] = useState(null);
   const tree = buildTree({ expandedNodeId })(nodes);
@@ -148,6 +149,10 @@ const TreeView = ({
     const shouldContract = node.expanded || node.onPath;
     setExpandedNodeId(shouldContract ? node.parent : node.id);
   };
+
+  useEffect(() => {
+    if (focusNode) setExpandedNodeId(focusNode.id);
+  }, [focusNode && focusNode.id]);
 
   return (
     <section className="tree-view">

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -24,7 +24,11 @@ const ItemButton = props => {
       className={`tree-node__item-button ${className || ""}`}
       onClick={handleClick}
     >
-      {shouldShowAction(props) ? <NodeActionItem {...props} /> : null}
+      {shouldShowAction(props) ? (
+        <span className="tree-node__item-action-button">
+          <NodeActionItem {...props} />
+        </span>
+      ) : null}
 
       <div className="tree-node__title">
         <span className="tree-node__name">

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -63,10 +63,6 @@ const AnimateChildNodes = props => {
   };
 
   useEffect(() => {
-    requestAnimationFrame(() => setEntering(true));
-  }, []);
-
-  useEffect(() => {
     if (isInitial) {
       setIsInitial(false);
     } else {

--- a/src/app/components/taxonomy/TreeView.jsx
+++ b/src/app/components/taxonomy/TreeView.jsx
@@ -3,6 +3,7 @@ import { buildClassName } from "../../helpers/buildClassName";
 import { retrieveTranslation } from "../../helpers/multiLanguage";
 import { buildTree, countVisibleChildren, isLeaf } from "./taxonomy";
 import { omit } from "lodash/fp";
+import { getCssVarNumeric } from "../../helpers/getCssVar";
 
 const ItemButton = props => {
   const {
@@ -37,13 +38,11 @@ const ItemButton = props => {
 
 const AnimateChildNodes = props => {
   const { node, show } = props;
-  const duration = parseInt(
-    getComputedStyle(document.body).getPropertyValue(
-      "--tree-animation-duration"
-    )
-  );
+  const duration = getCssVarNumeric("--tree-animation-duration");
 
-  const itemHeight = 47.6;
+  const itemHeight =
+    getCssVarNumeric("--tree-item-height") +
+    getCssVarNumeric("--tree-item-margin-y");
 
   const [isInitial, setIsInitial] = useState(true);
   const [entering, setEntering] = useState(false);

--- a/src/app/components/taxonomy/taxonomy.js
+++ b/src/app/components/taxonomy/taxonomy.js
@@ -84,11 +84,9 @@ export const isTaxonomyTable = table => table && table.type === "taxonomy";
 
 // countVisibleChildren : TreeNode -> Int
 export const countVisibleChildren = node =>
-  node.expanded
-    ? node.children.length
-    : node.onPath
-    ? 1 +
-      countVisibleChildren(
-        node.children.find(child => child.onPath || child.expanded)
-      )
+  node.expanded || node.onPath
+    ? node.children.length +
+      node.children
+        .map(child => countVisibleChildren(child))
+        .reduce((a, b) => a + b, 0)
     : 0;

--- a/src/app/components/taxonomy/taxonomy.js
+++ b/src/app/components/taxonomy/taxonomy.js
@@ -23,7 +23,7 @@ import getDisplayValue from "../../helpers/getDisplayValue";
 // tableToTreeNodes : { rows : List Row } -> List BuildTreeNode
 export const tableToTreeNodes = ({ rows }) =>
   (rows || []).map(({ id, cells, values }) => {
-    const displayValue = getDisplayValue(cells[0], values[0]);
+    const displayValue = getDisplayValue(cells[0].column, values[0]);
     const parentId = f.prop([3, 0, "id"], values); // id of first (and only) link value in column 4
 
     return {

--- a/src/app/components/taxonomy/taxonomy.js
+++ b/src/app/components/taxonomy/taxonomy.js
@@ -57,12 +57,15 @@ export const buildTree = ({ expandedNodeId }) => nodes => {
 export const getPathToNode = nodes => {
   const nodeRecord = f.keyBy("id", nodes);
   return node => {
-    const go = (curNode, path) => {
-      const parent = curNode && curNode.parent && nodeRecord[curNode.parent];
+    let curNode = node;
+    let path = [];
+    while (curNode) {
+      const parent = curNode.parent && nodeRecord[curNode.parent];
       if (parent) path.unshift(parent);
-      return parent ? go(parent, path) : path;
-    };
-    return go(node, []);
+      curNode = parent;
+    }
+
+    return path;
   };
 };
 

--- a/src/app/components/taxonomy/taxonomy.js
+++ b/src/app/components/taxonomy/taxonomy.js
@@ -81,3 +81,14 @@ export const isLeaf = node => node && f.isEmpty(node.children);
 
 // isTaxonomyTable : Table -> Boolean
 export const isTaxonomyTable = table => table && table.type === "taxonomy";
+
+// countVisibleChildren : TreeNode -> Int
+export const countVisibleChildren = node =>
+  node.expanded
+    ? node.children.length
+    : node.onPath
+    ? 1 +
+      countVisibleChildren(
+        node.children.find(child => child.onPath || child.expanded)
+      )
+    : 0;

--- a/src/app/constants/TableauxConstants.js
+++ b/src/app/constants/TableauxConstants.js
@@ -44,7 +44,8 @@ const grudConstants = {
     TABLE_VIEW: null,
     MEDIA_VIEW: null,
     DASHBOARD_VIEW: null,
-    FRONTEND_SERVICE_VIEW: null
+    FRONTEND_SERVICE_VIEW: null,
+    TAXONOMY_DASHBOARD_VIEW: null
   }),
 
   Alignments: keyMirror({

--- a/src/app/helpers/functools.js
+++ b/src/app/helpers/functools.js
@@ -535,6 +535,14 @@ function time(arg1, arg2) {
   };
 }
 
+const intersperse = curryN(2)((delim, coll) =>
+  coll.reduce((accum, next, idx) => {
+    accum.push(next);
+    if (idx < coll.length - 1) accum.push(delim);
+    return accum;
+  }, [])
+);
+
 export {
   Maybe,
   Just,
@@ -572,5 +580,6 @@ export {
   mapP,
   mergeArrays,
   usePropAsKey,
-  time
+  time,
+  intersperse
 };

--- a/src/app/helpers/functools.test.js
+++ b/src/app/helpers/functools.test.js
@@ -7,7 +7,8 @@ import {
   replaceMoustache,
   slidingWindow,
   usePropAsKey,
-  where
+  where,
+  intersperse
 } from "./functools";
 
 describe("functools", () => {
@@ -202,6 +203,11 @@ describe("functools", () => {
     it("is nil safe", () => {
       expect(usePropAsKey()(arr)).toEqual({});
       expect(usePropAsKey("foo")()).toEqual({});
+    });
+  });
+  describe("intersperse()", () => {
+    it("should intersperse elements between array items", () => {
+      expect(intersperse("x", [1, 2, 3])).toEqual([1, "x", 2, "x", 3]);
     });
   });
 });

--- a/src/app/helpers/getCssVar.js
+++ b/src/app/helpers/getCssVar.js
@@ -1,0 +1,6 @@
+// getCssVar : String -> String
+export const getCssVar = varName =>
+  getComputedStyle(document.body).getPropertyValue(varName);
+
+// getCssVarNumeric : String -> Number
+export const getCssVarNumeric = varName => parseInt(getCssVar(varName)) || 0;

--- a/src/app/helpers/useOutsideClick.jsx
+++ b/src/app/helpers/useOutsideClick.jsx
@@ -1,0 +1,35 @@
+/*
+ * react-onclickoutside won't work with functional components.
+ * This is a replacement as suggested by the react-onclickoutside library.
+ * It is meant to be used in an useEffect hook, like
+ *
+ * useEffect(outsideClickEffect({
+ *   shouldListen: popupOpen,
+ *   containerRef: myRef,
+ *   onOutsideClick: closePopup
+ * }), [popupOpen, myRef.current])
+ *
+ * The useEffect's cleanup mechanism will take care of removing event listeners.
+ */
+
+const outsideClickEffect = ({
+  shouldListen, // Boolean
+  containerRef, // React.leagacyRef
+  onOutsideClick // Html.Event -> ()
+}) => () => {
+  if (!shouldListen || !containerRef.current) return;
+  else {
+    const handleOutsideClick = event => {
+      if (!containerRef.current || containerRef.current.contains(event.target))
+        return;
+      onOutsideClick(event);
+    };
+    const handleCleanUp = () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
+    document.addEventListener("click", handleOutsideClick);
+    return handleCleanUp;
+  }
+};
+
+export { outsideClickEffect };

--- a/src/app/redux/actionCreators.js
+++ b/src/app/redux/actionCreators.js
@@ -627,13 +627,19 @@ const editColumn = (columnId, tableId, data) => {
   };
 };
 
-const createAndLoadRow = async (dispatch, tableId) => {
-  const freshRow = await makeRequest({
+const createAndLoadRow = async (dispatch, tableId, { columns, rows } = {}) => {
+  const response = await makeRequest({
     apiRoute: API_ROUTES.toRows(tableId),
-    method: "POST"
+    method: "POST",
+    ...(columns && rows && { data: { columns, rows } })
   });
-  dispatch(addRows(tableId, [freshRow]));
-  return freshRow;
+  const responseRows = Array.isArray(response)
+    ? response
+    : Array.isArray(response.rows)
+    ? response.rows
+    : [];
+  dispatch(addRows(tableId, responseRows));
+  return responseRows;
 };
 
 export const addEmptyRowAndOpenEntityView = (
@@ -674,6 +680,7 @@ const actionCreators = {
   loadTables: loadTables,
   loadColumns: loadColumns,
   loadAllRows: loadAllRows,
+  createAndLoadRow,
   toggleColumnVisibility: toggleColumnVisibility,
   setColumnsVisible: setColumnsVisible,
   hideAllColumns: hideAllColumns,

--- a/src/app/redux/reducers/rows.js
+++ b/src/app/redux/reducers/rows.js
@@ -92,7 +92,7 @@ const annotationsToObject = annotations => {
   return annObj;
 };
 
-const rowValuesToCells = (table, columns) => rows => {
+export const rowValuesToCells = (table, columns) => rows => {
   const rowsWithCells = rows.map(row => {
     const fakeRow = { id: row.id };
     return {

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -13,6 +13,7 @@
   "info": "Hinweis",
   "warning": "Warnung",
   "no": "Nein",
+  "open": "Öffnen",
   "save": "Speichern",
   "yes": "Ja",
   "ok": "Ok",

--- a/src/locales/de/header.json
+++ b/src/locales/de/header.json
@@ -2,8 +2,9 @@
   "menu": {
     "media": "Medien",
     "tables": "Tabellen",
-      "dashboard": "Dashboard",
-      "logout": "Ausloggen"
+    "dashboard": "Dashboard",
+    "logout": "Ausloggen",
+    "taxonomies": "Kategorien"
   },
   "pageTitle": {
     "media": "Medien Management",

--- a/src/locales/de/table.json
+++ b/src/locales/de/table.json
@@ -174,6 +174,7 @@
     "add-sibling-below": "Neue Kategorie danach",
     "delete": "Löschen",
     "edit": "Bearbeiten",
+    "link-category": "Kategorie hinzufügen",
     "title": "Kategorien"
   }
 }

--- a/src/locales/de/table.json
+++ b/src/locales/de/table.json
@@ -168,5 +168,12 @@
     "enter-link": "Hier URL eingeben",
     "linked-text": "Linktext",
     "insert-link": "Link hinzufügen"
+  },
+  "taxonomy": {
+    "add-child": "Neue Subkategorie",
+    "add-sibling-below": "Neue Kategorie danach",
+    "delete": "Löschen",
+    "edit": "Bearbeiten",
+    "title": "Kategorien"
   }
 }

--- a/src/locales/de/table.json
+++ b/src/locales/de/table.json
@@ -175,6 +175,8 @@
     "delete": "Löschen",
     "edit": "Bearbeiten",
     "link-category": "Kategorie hinzufügen",
+    "search-input-placeholder": "Suche nach Kategorien oder Datensätzen",
+    "search-no-results": "Keine Suchergebnisse",
     "title": "Kategorien"
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -13,6 +13,7 @@
   "info": "Info",
   "warning": "Warning",
   "no": "No",
+  "open": "open",
   "save": "Save",
   "yes": "Yes",
   "ok": "Ok",

--- a/src/locales/en/header.json
+++ b/src/locales/en/header.json
@@ -2,8 +2,9 @@
   "menu": {
     "media": "Media",
     "tables": "Tables",
-      "dashboard": "Dashboard",
-      "logout": "Log out"
+    "dashboard": "Dashboard",
+    "logout": "Log out",
+    "taxonomies": "Categories"
   },
   "pageTitle": {
     "media": "Media Management",

--- a/src/locales/en/table.json
+++ b/src/locales/en/table.json
@@ -168,5 +168,12 @@
     "enter-link": "Enter URL here",
     "linked-text": "Link text",
     "insert-link": "Add link"
+  },
+  "taxonomy": {
+    "add-child": "Add child category",
+    "add-sibling-below": "Add sibling category after",
+    "delete": "Delete",
+    "edit": "Edit",
+    "title": "Categories"
   }
 }

--- a/src/locales/en/table.json
+++ b/src/locales/en/table.json
@@ -175,6 +175,8 @@
     "delete": "Delete",
     "edit": "Edit",
     "link-category": "Link category",
+    "search-input-placeholder": "Search for categories or records",
+    "search-no-results": "No results found",
     "title": "Categories"
   }
 }

--- a/src/locales/en/table.json
+++ b/src/locales/en/table.json
@@ -174,6 +174,7 @@
     "add-sibling-below": "Add sibling category after",
     "delete": "Delete",
     "edit": "Edit",
+    "link-category": "Link category",
     "title": "Categories"
   }
 }

--- a/src/scss/TaxonomyDashboard.scss
+++ b/src/scss/TaxonomyDashboard.scss
@@ -1,0 +1,51 @@
+.taxonomy-dashboard {
+  h1 {
+    font-size: 20px;
+    font-weight: 600;
+  }
+  &__content-wrapper {
+    padding-top: 55px;
+    color: $color-very-dark;
+  }
+
+  &__header {
+    background-color: $color-white;
+    padding: 32px 56px;
+  }
+
+  &__content {
+    padding: 56px;
+    padding-right: 0;
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    height: 210px;
+    width: 320px;
+    background-color: $color-white;
+    border-radius: 8px;
+    padding: 24px 32px;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    margin-right: 56px;
+    margin-bottom: 56px;
+
+    &__header {
+      margin-bottom: 8px;
+    }
+    &__content {
+      flex: 1;
+      overflow: auto;
+      color: $color-text-medium-grey;
+    }
+    &__footer {
+      padding-top: 16px;
+    }
+
+    .button {
+      @include button-look();
+    }
+  }
+}

--- a/src/scss/TaxonomyLinkOverlay.scss
+++ b/src/scss/TaxonomyLinkOverlay.scss
@@ -50,6 +50,11 @@
         display: flex;
         align-items: center;
         padding: 0 24px;
+        white-space: nowrap;
+        max-width: calc(
+          100% - var(--tree-item-height) - var(--tree-item-margin-y)
+        );
+        box-sizing: border-box;
 
         &-title {
           color: $color-primary-contrast-text;
@@ -58,14 +63,15 @@
       }
 
       .set-link-button {
-        width: var(--tree-item-height);
+        min-width: var(--tree-item-height);
         max-width: var(--tree-item-height);
         margin-right: 8px;
       }
 
       &__path {
         color: transparentize($color-primary-contrast-text, 0.3);
-        max-width: 50%;
+        flex: 0 1 auto;
+        min-width: 0;
         display: flex;
         &-separator {
           margin: 0 4px;

--- a/src/scss/TaxonomyLinkOverlay.scss
+++ b/src/scss/TaxonomyLinkOverlay.scss
@@ -1,4 +1,5 @@
-.overlay-wrapper.link-overlay.link-overlay--taxonomy {
+.overlay-wrapper.link-overlay.link-overlay--taxonomy,
+.overlay-wrapper.select-link-target-overlay.select-link-target-overlay--taxonomy {
   .overlay-content {
     overflow: hidden;
     flex: 1;

--- a/src/scss/TaxonomyLinkOverlay.scss
+++ b/src/scss/TaxonomyLinkOverlay.scss
@@ -9,6 +9,7 @@
   .overlay-main-content {
     overflow-y: auto;
     margin-bottom: 0;
+    padding: 0 24px;
   }
 
   .overlay-subheader {
@@ -29,6 +30,33 @@
       }
       .number {
         color: $color-very-dark;
+      }
+    }
+
+    .linked-item {
+      display: flex;
+      height: var(--tree-item-height);
+      &:not(:last-of-type) {
+        margin-bottom: var(--tree-item-margin-y);
+      }
+      &__content {
+        flex: 1;
+        background-color: $color-primary;
+        border-radius: 4px;
+        display: flex;
+        align-items: center;
+        padding: 0 24px;
+
+        &-title {
+          color: $color-primary-contrast-text;
+          font-weight: bold;
+        }
+      }
+
+      .set-link-button {
+        width: var(--tree-item-height);
+        max-width: var(--tree-item-height);
+        margin-right: 8px;
       }
     }
   }

--- a/src/scss/TaxonomyLinkOverlay.scss
+++ b/src/scss/TaxonomyLinkOverlay.scss
@@ -1,0 +1,54 @@
+.overlay-wrapper.link-overlay.link-overlay--taxonomy {
+  .overlay-content {
+    overflow: hidden;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .overlay-main-content {
+    overflow-y: auto;
+    margin-bottom: 0;
+  }
+
+  .overlay-subheader {
+    font-size: 13px;
+
+    &__title {
+      font-size: 16px;
+      padding-bottom: 8px;
+      font-weight: 600;
+    }
+
+    .cardinality-count {
+      font-size: 16px;
+      font-weight: 500;
+      padding-bottom: 8px;
+      span:not(:first-child) {
+        margin-left: 4px;
+      }
+      .number {
+        color: $color-very-dark;
+      }
+    }
+  }
+
+  .set-link-button {
+    flex: 1;
+    height: 100%;
+    text-align: center;
+    border-radius: 4px;
+    background-color: $color-light-link-color;
+    color: $color-primary;
+
+    &:hover {
+      background-color: $color-subtle-grey;
+    }
+
+    &--disabled,
+    &--disabled:hover {
+      background-color: $color-text-light-grey;
+      color: $color-text-medium-grey;
+    }
+  }
+}

--- a/src/scss/TaxonomyLinkOverlay.scss
+++ b/src/scss/TaxonomyLinkOverlay.scss
@@ -33,6 +33,10 @@
       }
     }
 
+    .taxonomy-link-overlay__linked-items {
+      margin-top: 16px;
+    }
+
     .linked-item {
       display: flex;
       height: var(--tree-item-height);
@@ -57,6 +61,27 @@
         width: var(--tree-item-height);
         max-width: var(--tree-item-height);
         margin-right: 8px;
+      }
+
+      &__path {
+        color: transparentize($color-primary-contrast-text, 0.3);
+        max-width: 50%;
+        display: flex;
+        &-separator {
+          margin: 0 4px;
+        }
+        &-step {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          cursor: pointer;
+          &:hover {
+            text-decoration: underline;
+          }
+          &:last-of-type {
+            margin-right: 4px;
+          }
+        }
       }
     }
   }

--- a/src/scss/TaxonomyLinkOverlay.scss
+++ b/src/scss/TaxonomyLinkOverlay.scss
@@ -83,6 +83,7 @@
           cursor: pointer;
           &:hover {
             text-decoration: underline;
+            min-width: fit-content;
           }
           &:last-of-type {
             margin-right: 4px;

--- a/src/scss/TaxonomySearch.scss
+++ b/src/scss/TaxonomySearch.scss
@@ -73,6 +73,9 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         font-style: italic;
+        &:hover {
+          min-width: fit-content;
+        }
 
         &:last-child {
           margin-right: 8px;

--- a/src/scss/TaxonomySearch.scss
+++ b/src/scss/TaxonomySearch.scss
@@ -1,0 +1,74 @@
+.taxonomy-search {
+  position: relative;
+  &__wrapper {
+    position: relative;
+    font-size: 18px;
+  }
+  &__input {
+    width: 100%;
+    padding: 8px 16px;
+    box-sizing: border-box;
+    border-radius: 4px;
+    outline: none;
+    border: 1px solid transparent;
+  }
+  &__icon {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: $color-text-medium-grey;
+  }
+
+  &__results {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    background-color: $color-white;
+    max-height: 40vh;
+    overflow: auto;
+    box-shadow: 0 15px 25px 5px $color-very-dark;
+    border-radius: 4px;
+  }
+
+  &__result-item {
+    &:hover {
+      background-color: transparentize($color-text-medium-grey, 0.8);
+      cursor: pointer;
+    }
+    display: flex;
+    padding: 8px 16px;
+    color: $color-very-dark;
+
+    &__title {
+      font-weight: bold;
+    }
+
+    &--leaf {
+      color: $color-primary;
+      border-left: 8px solid $color-primary;
+      padding-left: 8px;
+    }
+
+    &__path {
+      display: flex;
+      max-width: 50%;
+      color: $color-text-medium-grey;
+
+      &-step {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-style: italic;
+
+        &:last-child {
+          margin-right: 8px;
+        }
+      }
+      &-separator {
+        margin: 0 4px;
+      }
+    }
+  }
+}

--- a/src/scss/TaxonomySearch.scss
+++ b/src/scss/TaxonomySearch.scss
@@ -1,4 +1,9 @@
 .taxonomy-search {
+  &.filter-bar {
+    .taxonomy-search__results {
+      top: calc(100% - 16px);
+    }
+  }
   position: relative;
   &__wrapper {
     position: relative;
@@ -28,27 +33,32 @@
     background-color: $color-white;
     max-height: 40vh;
     overflow: auto;
-    box-shadow: 0 15px 25px 5px $color-very-dark;
+    box-shadow: 0 15px 25px 5px $color-text-medium-grey;
     border-radius: 4px;
   }
 
   &__result-item {
+    margin: 2px 0;
     &:hover {
       background-color: transparentize($color-text-medium-grey, 0.8);
       cursor: pointer;
     }
-    display: flex;
-    padding: 8px 16px;
-    color: $color-very-dark;
+    &__wrapper {
+      display: flex;
+      padding: 8px 16px;
+      color: $color-very-dark;
+    }
 
     &__title {
       font-weight: bold;
     }
 
     &--leaf {
-      color: $color-primary;
-      border-left: 8px solid $color-primary;
-      padding-left: 8px;
+      border-left: 6px solid $color-primary;
+      .taxonomy-search__result-item__wrapper {
+        color: $color-primary;
+        padding-left: 10px;
+      }
     }
 
     &__path {

--- a/src/scss/TaxonomySearch.scss
+++ b/src/scss/TaxonomySearch.scss
@@ -35,6 +35,7 @@
     overflow: auto;
     box-shadow: 0 15px 25px 5px $color-text-medium-grey;
     border-radius: 4px;
+    z-index: 1;
   }
 
   &__result-item {
@@ -63,7 +64,8 @@
 
     &__path {
       display: flex;
-      max-width: 50%;
+      flex: 0 1 auto;
+      min-width: 0;
       color: $color-text-medium-grey;
 
       &-step {

--- a/src/scss/TaxonomySearch.scss
+++ b/src/scss/TaxonomySearch.scss
@@ -39,6 +39,12 @@
   }
 
   &__result-item {
+    &--placeholder {
+      display: flex;
+      align-items: center;
+      padding: 8px 16px;
+      color: $color-text-medium-grey;
+    }
     margin: 2px 0;
     &:hover {
       background-color: transparentize($color-text-medium-grey, 0.8);

--- a/src/scss/TaxonomyTable.scss
+++ b/src/scss/TaxonomyTable.scss
@@ -1,14 +1,67 @@
+@mixin taxonomy-interactive-element(
+  $idle-color: $color-text-light-grey,
+  $hover-color: $color-light-blue,
+  $active-color: $color-primary
+) {
+  background-color: $color-white;
+  border-radius: 4px;
+
+  border-color: $idle-color;
+  svg > * {
+    fill: $idle-color;
+  }
+
+  &:hover {
+    border-color: $hover-color;
+    svg > * {
+      fill: $hover-color;
+    }
+  }
+
+  &--active,
+  &:focus {
+    border-color: $active-color;
+    svg > * {
+      fill: $active-color;
+    }
+  }
+}
+
 .tableaux-table--taxonomy {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
   .table__subheader {
     color: $color-very-dark;
     background-color: $color-white;
     padding: 32px 56px;
+    box-shadow: 0 1px 15px 1px $color-text-light-grey;
+    z-index: 1;
+
     &-title {
       font-size: 20px;
       font-weight: 600;
     }
+
+    .taxonomy-table__search {
+      width: 720px;
+      margin-top: 24px;
+
+      .taxonomy-search__input {
+        @include taxonomy-interactive-element();
+        color: $color-text-medium-grey;
+        &--placeholder {
+          font-style: italic;
+        }
+      }
+    }
   }
-  overflow-y: auto;
+
+  .taxonomy-table__tree {
+    overflow-y: auto;
+    flex: 1;
+  }
   .tree-node {
     &__menu-button {
       flex: 1;

--- a/src/scss/TaxonomyTable.scss
+++ b/src/scss/TaxonomyTable.scss
@@ -1,0 +1,76 @@
+.tableaux-table--taxonomy {
+  .tree-node {
+    &__menu-button {
+      flex: 1;
+      height: 100%;
+      background-color: $color-white;
+      border-radius: 4px;
+      @include flex-centered();
+      position: relative;
+
+      &:hover {
+        background-color: $color-primary-hover;
+        color: $color-primary;
+        & > * {
+          fill: $color-primary;
+        }
+      }
+
+      &--open,
+      &--open:hover {
+        background-color: $color-primary;
+        color: $color-primary-contrast-text;
+        & > * {
+          fill: $color-primary-contrast-text;
+        }
+      }
+    }
+
+    &__menu-popup {
+      position: absolute;
+      left: calc(100% + 8px);
+      top: 0;
+      background-color: $color-white;
+      box-shadow: 0 0 15px $color-text-light-grey;
+      border-radius: 4px;
+
+      &__item-group {
+        &:not(:last-of-type) {
+          border-bottom: 1px solid $color-text-light-grey;
+        }
+      }
+
+      &__item {
+        display: grid;
+        padding: 12px 16px;
+        grid-template-columns: var(--tree-item-height) 1fr;
+        color: $color-very-dark;
+
+        & > svg > * {
+          fill: $color-very-dark;
+        }
+
+        .item__icon {
+          @include flex-centered();
+          font-size: 16px;
+
+          .flip-lr {
+            transform: scaleX(-1);
+          }
+
+          .rotate-90 {
+            rotate: 90deg;
+          }
+        }
+
+        .item-title {
+          white-space: nowrap;
+        }
+
+        &:hover {
+          background-color: transparentize($color-text-light-grey, 0.8);
+        }
+      }
+    }
+  }
+}

--- a/src/scss/TaxonomyTable.scss
+++ b/src/scss/TaxonomyTable.scss
@@ -1,4 +1,13 @@
 .tableaux-table--taxonomy {
+  .table__subheader {
+    color: $color-very-dark;
+    background-color: $color-white;
+    padding: 32px 56px;
+    &-title {
+      font-size: 20px;
+      font-weight: 600;
+    }
+  }
   overflow-y: auto;
   .tree-node {
     &__menu-button {

--- a/src/scss/TaxonomyTable.scss
+++ b/src/scss/TaxonomyTable.scss
@@ -1,4 +1,5 @@
 .tableaux-table--taxonomy {
+  overflow-y: auto;
   .tree-node {
     &__menu-button {
       flex: 1;

--- a/src/scss/TreeView.scss
+++ b/src/scss/TreeView.scss
@@ -1,0 +1,7 @@
+.tree {
+  .tree-node {
+    &__item-button {
+      display: flex;
+    }
+  }
+}

--- a/src/scss/TreeView.scss
+++ b/src/scss/TreeView.scss
@@ -45,6 +45,13 @@
         color: $color-dark;
       }
     }
+
+    &--leaf {
+      .tree-node__title {
+        color: $color-primary;
+        border-left: 8px solid $color-primary;
+      }
+    }
   }
 
   .subtree {

--- a/src/scss/TreeView.scss
+++ b/src/scss/TreeView.scss
@@ -1,7 +1,46 @@
 .tree {
+  padding: 24px;
+  max-width: 900px;
+
   .tree-node {
+    .hfill {
+      flex: 1;
+    }
     &__item-button {
       display: flex;
+      align-items: center;
+      margin: 8px 0;
     }
+
+    &__title {
+      flex: 1;
+      display: flex;
+      padding: 12px 24px;
+      font-weight: bold;
+      border-radius: 4px;
+    }
+
+    &__child-count {
+      margin-left: 4px;
+    }
+
+    &--on-path,
+    &--expanded {
+      .tree-node__title {
+        background-color: $color-primary;
+        color: $color-primary-contrast-text;
+      }
+    }
+
+    &--default {
+      .tree-node__title {
+        background-color: $color-white;
+        color: $color-dark;
+      }
+    }
+  }
+
+  .subtree {
+    padding-left: 16px;
   }
 }

--- a/src/scss/TreeView.scss
+++ b/src/scss/TreeView.scss
@@ -1,5 +1,7 @@
 :root {
   --tree-animation-duration: 300ms;
+  --tree-item-height: 39.6px;
+  --tree-item-margin-y: 8px;
 }
 
 .tree {
@@ -11,10 +13,19 @@
       flex: 1;
     }
     &__item-button {
+      height: var(--tree-item-height);
       cursor: pointer;
       display: flex;
       align-items: center;
-      margin: 8px 0;
+      margin: var(--tree-item-margin-y) 0;
+    }
+    &__item-action-button {
+      height: var(--tree-item-height);
+      width: var(--tree-item-height);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-right: 8px;
     }
 
     &__title {

--- a/src/scss/TreeView.scss
+++ b/src/scss/TreeView.scss
@@ -36,6 +36,7 @@
       border-radius: 4px;
       transition: background-color var(--tree-animation-duration) ease-in-out,
         color var(--tree-animation-duration) ease-in-out;
+      min-height: 13px;
     }
 
     &__child-count {
@@ -68,7 +69,7 @@
   .subtree {
     padding: 0;
     margin: 0;
-    padding-left: 16px;
+    padding-left: 32px;
     transition: all var(--tree-animation-duration) ease-in;
     height: 0;
     transform-origin: top;

--- a/src/scss/TreeView.scss
+++ b/src/scss/TreeView.scss
@@ -1,3 +1,7 @@
+:root {
+  --tree-animation-duration: 300ms;
+}
+
 .tree {
   padding: 24px;
   max-width: 900px;
@@ -7,6 +11,7 @@
       flex: 1;
     }
     &__item-button {
+      cursor: pointer;
       display: flex;
       align-items: center;
       margin: 8px 0;
@@ -18,6 +23,8 @@
       padding: 12px 24px;
       font-weight: bold;
       border-radius: 4px;
+      transition: background-color var(--tree-animation-duration) ease-in-out,
+        color var(--tree-animation-duration) ease-in-out;
     }
 
     &__child-count {
@@ -41,6 +48,24 @@
   }
 
   .subtree {
+    padding: 0;
+    margin: 0;
     padding-left: 16px;
+    transition: all var(--tree-animation-duration) ease-in;
+    height: 0;
+    transform-origin: top;
+    display: block;
+    transform: scaleY(0);
+
+    &--show {
+      transform: scaleY(1);
+    }
+    &--entering {
+      transform: scaleY(1);
+    }
+    &--leaving {
+      transform: scaleY(0);
+      height: 0;
+    }
   }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -55,4 +55,5 @@
 "TreeView",
 "TaxonomyTable",
 "TaxonomyLinkOverlay",
-"TaxonomySearch";
+"TaxonomySearch",
+"TaxonomyDashboard";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -52,4 +52,5 @@
 "headerLanguageSwitcher",
 "frontendServiceNotFound",
 "selectLinkTargetOverlay",
-"TreeView";
+"TreeView",
+"TaxonomyTable";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -54,4 +54,5 @@
 "selectLinkTargetOverlay",
 "TreeView",
 "TaxonomyTable",
-"TaxonomyLinkOverlay";
+"TaxonomyLinkOverlay",
+"TaxonomySearch";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -51,4 +51,5 @@
 "connectionstatus",
 "headerLanguageSwitcher",
 "frontendServiceNotFound",
-"selectLinkTargetOverlay";
+"selectLinkTargetOverlay",
+"TreeView";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -53,4 +53,5 @@
 "frontendServiceNotFound",
 "selectLinkTargetOverlay",
 "TreeView",
-"TaxonomyTable";
+"TaxonomyTable",
+"TaxonomyLinkOverlay";

--- a/src/scss/table.scss
+++ b/src/scss/table.scss
@@ -82,7 +82,10 @@ body div div.column-header-context-menu {
 }
 
 .tableaux-table {
-  background-color: white;
+  &--settings,
+  &--generic {
+    background-color: $color-white;
+  }
   position: absolute;
   top: 0;
   left: 0;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -19,6 +19,7 @@ $status-error-background-color: #ffa088;*/
 $color-body-background: #EFEFEF;
 $color-background-very-light-grey: #F8F8F8;
 $color-primary: #3296DC;
+$color-primary-hover: #96D9FF;
 $color-primary-lighter: #91C8FF;
 $color-primary-darker: darken($color-primary, 10);
 $color-subtle-grey: #DFDFDF;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -16,38 +16,38 @@ $status-error-border-color: #ff8080;
 $status-error-background-color: #ffa088;*/
 
 // Colors ----------------------------------- //
-$color-body-background: #EFEFEF;
-$color-background-very-light-grey: #F8F8F8;
-$color-primary: #3296DC;
-$color-primary-hover: #96D9FF;
-$color-primary-lighter: #91C8FF;
+$color-body-background: #efefef;
+$color-background-very-light-grey: #f8f8f8;
+$color-primary: #3296dc;
+$color-primary-hover: #96d9ff;
+$color-primary-lighter: #91c8ff;
 $color-primary-darker: darken($color-primary, 10);
-$color-subtle-grey: #DFDFDF;
-$color-text-light-grey: #C4C4C4;
+$color-subtle-grey: #dfdfdf;
+$color-text-light-grey: #c4c4c4;
 $color-dark: #555555;
 $color-text-medium-grey: #999999;
 $color-very-dark: #333333;
-$color-button-grey: #A0A0A0;
-$color-border-grey: #EFEFEF;
-$color-primary-contrast-text: #FFFFFF;
+$color-button-grey: #a0a0a0;
+$color-border-grey: #efefef;
+$color-primary-contrast-text: #ffffff;
 $color-primary-text: #333333;
-$color-link-color: #E4EFF7;
-$color-grey-dark: #DEDEDE;
-$color-light-link-color: #E7F1F8;
-$color-darker-link-color: #C5D9E8;
-$color-text-link-color: #7C94A6;
-$color-selected-row: #F3FAFF;
-$color-select-list-focus: #E8E8E8;
-$color-select-list-selected: #E8F6FF;
-$color-success: #5EC786;
+$color-link-color: #e4eff7;
+$color-grey-dark: #dedede;
+$color-light-link-color: #e7f1f8;
+$color-darker-link-color: #c5d9e8;
+$color-text-link-color: #7c94a6;
+$color-selected-row: #f3faff;
+$color-select-list-focus: #e8e8e8;
+$color-select-list-selected: #e8f6ff;
+$color-success: #5ec786;
 $color-green: $color-success;
-$color-red: #D86357;
+$color-red: #d86357;
 $color-light-blue: #bde4ff;
 $color-very-light-blue: #e7f1f8;
-$dark-blue-grey-background: #3C4246;
-$color-background-disabled: #FAFAFA;
+$dark-blue-grey-background: #3c4246;
+$color-background-disabled: #fafafa;
 $color-foreground-disabled: $color-text-medium-grey;
-$color-needs-translation: #FB9429;
+$color-needs-translation: #fb9429;
 $color-needs-translation-dark: darken(#ff9600, 5);
 $color-fully-translated: lighten($color-green, 30);
 $color-hover-background: $color-light-link-color;
@@ -69,16 +69,16 @@ $color-overlay-success: #6ec;
 $color-overlay-warning: #f55;
 
 $color-hover-dark: #4a4f53;
-$color-revision-added: #D1F2E7;
-$color-revision-link-added: #66D6B0;
-$color-revision-deleted: #DFDFDF;
-$color-revision-filter-background: #464B4F;
+$color-revision-added: #d1f2e7;
+$color-revision-link-added: #66d6b0;
+$color-revision-deleted: #dfdfdf;
+$color-revision-filter-background: #464b4f;
 
-$color-header-gradient-start: #2F95DB;
-$color-header-gradient-end: #15E2C3;
+$color-header-gradient-start: #2f95db;
+$color-header-gradient-end: #15e2c3;
 
 // Fonts ----------------------------------- //
-$font-main: 'Roboto', Helvetica Neue, Helvetica, Arial, sans-serif;
+$font-main: "Roboto", Helvetica Neue, Helvetica, Arial, sans-serif;
 $font-sec: $font-main;
 
 // Font sizes ----------------------------------- //
@@ -117,7 +117,12 @@ $space-height-link-delete-button: 23px;
   box-sizing: border-box;
 }
 
-@mixin status-dot($dot-color, $background-color, $diameter: 6px, $yoffset: -2px) {
+@mixin status-dot(
+  $dot-color,
+  $background-color,
+  $diameter: 6px,
+  $yoffset: -2px
+) {
   &:before {
     position: absolute;
     content: "";
@@ -141,8 +146,14 @@ $space-height-link-delete-button: 23px;
   }
 }
 
-@mixin status-dot-hovered($dot-color, $background-color, $diameter: 6px, $yoffset: -2px) {
-  &:before, &.inactive:before {
+@mixin status-dot-hovered(
+  $dot-color,
+  $background-color,
+  $diameter: 6px,
+  $yoffset: -2px
+) {
+  &:before,
+  &.inactive:before {
     position: absolute;
     content: "";
     width: $diameter;
@@ -189,4 +200,8 @@ $space-height-link-delete-button: 23px;
   &:hover .svg-icon-content * {
     fill: $color-hovered;
   }
+}
+
+.hfill {
+  flex: 1;
 }

--- a/src/static/img/icons/add-sub-item.svg
+++ b/src/static/img/icons/add-sub-item.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="12.3201"
+   viewBox="0 0 16 12.3201"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="add-sub-item.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="36.041667"
+     inkscape:cx="7.9907514"
+     inkscape:cy="6.0208092"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     inkscape:window-x="1920"
+     inkscape:window-y="96"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <rect
+     x="6.5"
+     y="7.8200998"
+     width="9"
+     height="4"
+     rx="0.5"
+     stroke="#333333"
+     stroke-linejoin="round"
+     id="rect2" />
+  <path
+     d="M 2.43994,2.67993 V 8.8199 c 0,0.5523 0.44772,1 1,1 H 6.5"
+     stroke="#333333"
+     id="path4" />
+  <rect
+     x="0"
+     y="0"
+     width="16"
+     height="5"
+     rx="1"
+     fill="#333333"
+     id="rect6" />
+</svg>


### PR DESCRIPTION
## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

- Übersetzt Taxonomietabellen rekursiv in Bäume
- Enthält bereits Helper für die Suche in Taxonomietabellen (String-Prädikat gibt Nodes mit Breadcrumb-Pfad zurück)
- Führt eine parametrisierbare Baumansicht ein (Events und Menüs können mitgegeben werden)
- Rendert abhängig vom Tabellentypen entweder "VirtualTable" oder "TreeView"
- Styling ist erst mal minimal; Fancy Lines und Animationen fehlen noch

Zum testen braucht man eine aktuelle Version des Backend-Masters, die Taxonomietabellen unterstützt. Dort einfach `POST /api/tables { type: "taxonomy", name: "test table" }`