### PR TITLE
AC-1022: Fix multilang link/attachment history entries

### DIFF
--- a/src/app/components/history/RevisionItem.jsx
+++ b/src/app/components/history/RevisionItem.jsx
@@ -67,7 +67,7 @@ const RevisionItem = props => {
       )}
       <div className="revision-item__content">
         <div className="revision-item__content-box">
-          <Diff revision={revision} diff={diff} cell={cell} />
+          <Diff revision={revision} diff={diff} cell={cell} langtag={langtag} />
         </div>
       </div>
     </div>

--- a/src/app/components/history/diffItems/LinkDiff.jsx
+++ b/src/app/components/history/diffItems/LinkDiff.jsx
@@ -15,14 +15,14 @@ const LinkState = {
 };
 
 const LinkDiff = props => {
-  const { diff } = props;
+  const { diff, langtag } = props;
 
   return diff.map(
     ({ add, del, value: { id, value }, currentDisplayValues = {} }) => {
       const displayValue = currentDisplayValues[id];
       const revisionValue = ifElse(
         f.isObject,
-        retrieveTranslation,
+        retrieveTranslation(langtag),
         f.identity,
         value
       );

--- a/src/app/components/history/history-helpers.js
+++ b/src/app/components/history/history-helpers.js
@@ -133,7 +133,9 @@ const getCurrentLinkDisplayValue = ({ tableId, column, langtag }) => rowId => {
 //------------------------------------------------------------------------------
 
 export const matchesLangtag = langtag => rev =>
-  rev.languageType === "language" ? f.has(langtag, rev.value) : true;
+  !Array.isArray(rev.value) && rev.languageType === "language"
+    ? f.has(langtag, rev.value)
+    : true;
 
 export const filterHasValidDateProp = (prop, filter) =>
   maybe(filter)

--- a/src/app/helpers/functools.js
+++ b/src/app/helpers/functools.js
@@ -543,6 +543,16 @@ const intersperse = curryN(2)((delim, coll) =>
   }, [])
 );
 
+const scan = (fn, start, coll) => {
+  const results = [];
+  coll.forEach((value, idx) => {
+    const prevValue = idx === 0 ? start : results[idx - 1];
+    const result = fn(prevValue, value, idx, results);
+    results.push(result);
+  });
+  return results;
+};
+
 export {
   Maybe,
   Just,
@@ -581,5 +591,6 @@ export {
   mergeArrays,
   usePropAsKey,
   time,
-  intersperse
+  intersperse,
+  scan
 };


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [ ] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Das problem sind nicht Multilangwerte bei Links, sondern dass Linkspalten als multilang definiert sind. Links und Attachment sind IMMER single lang, egal was in der Column steht.  
Hier wurde sich auf den `languageType`-Wert der Spalte verlassen und daher ist das Filtern gebrochen.  
Um das Problem überhaupt zu finden habe ich erst mal eine der Kernfunktionen refakturiert. Da das Ergebnis dann insgesamt performanter ist und auch bei langen Änderungshistorien nicht mehr abstürzen kann habe ich es dann so gelassen, auch wenn es etwas mehr Änderung als nötig ist.