### PR TITLE
[bugfix] AC-1025 - Changing visible columns can crash the frontend

### DIFF
--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -16,7 +16,13 @@ import {
   Directions,
   RowIdColumn
 } from "../../constants/TableauxConstants";
-import { doto, either, maybe, mapIndexed } from "../../helpers/functools";
+import {
+  doto,
+  either,
+  isNumber,
+  maybe,
+  mapIndexed
+} from "../../helpers/functools";
 import { isLocked } from "../../helpers/annotationHelper";
 import AddNewRowButton from "../rows/NewRow";
 import Cell, { getAnnotationState } from "../cells/Cell";
@@ -36,6 +42,8 @@ const STATUS_CELL_WIDTH = 120;
 const HEADER_HEIGHT = 37;
 const CELL_WIDTH = 300;
 const ROW_HEIGHT = 45;
+
+const safelyPassIndex = x => (isNumber(x) ? x : -1);
 
 export default class VirtualTable extends PureComponent {
   constructor(props) {
@@ -556,6 +564,7 @@ export default class VirtualTable extends PureComponent {
     const shouldIDColBeGrey =
       f.get("kind", columns[0] /*columns.first()*/) === ColumnKinds.concat &&
       rowCount * 45 + 37 > window.innerHeight; // table might scroll (data rows + button + 37 + tableaux-header) >
+    console.log({ columnIndex, rowIndex });
 
     return (
       <section
@@ -590,8 +599,8 @@ export default class VirtualTable extends PureComponent {
                 selectedCell={selectedCellKey}
                 expandedRows={expandedRowIds}
                 openAnnotations={!!openAnnotations && openAnnotations.cellId}
-                scrollToRow={rowIndex}
-                scrollToColumn={columnIndex}
+                scrollToRow={safelyPassIndex(rowIndex)}
+                scrollToColumn={safelyPassIndex(columnIndex)}
                 scrollToAlignment={align}
                 columnKeys={columnKeys}
                 overscanColumnCount={5}

--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -558,7 +558,6 @@ export default class VirtualTable extends PureComponent {
     const shouldIDColBeGrey =
       f.get("kind", columns[0] /*columns.first()*/) === ColumnKinds.concat &&
       rowCount * 45 + 37 > window.innerHeight; // table might scroll (data rows + button + 37 + tableaux-header) >
-    console.log({ columnIndex, rowIndex });
 
     return (
       <section

--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -16,13 +16,7 @@ import {
   Directions,
   RowIdColumn
 } from "../../constants/TableauxConstants";
-import {
-  doto,
-  either,
-  isNumber,
-  maybe,
-  mapIndexed
-} from "../../helpers/functools";
+import { doto, either, maybe, mapIndexed } from "../../helpers/functools";
 import { isLocked } from "../../helpers/annotationHelper";
 import AddNewRowButton from "../rows/NewRow";
 import Cell, { getAnnotationState } from "../cells/Cell";
@@ -43,7 +37,7 @@ const HEADER_HEIGHT = 37;
 const CELL_WIDTH = 300;
 const ROW_HEIGHT = 45;
 
-const safelyPassIndex = x => (isNumber(x) ? x : -1);
+const safelyPassIndex = x => (f.isNumber(x) && !f.isNaN(x) ? x : -1);
 
 export default class VirtualTable extends PureComponent {
   constructor(props) {

--- a/src/app/helpers/functools.js
+++ b/src/app/helpers/functools.js
@@ -535,6 +535,8 @@ function time(arg1, arg2) {
   };
 }
 
+const isNumber = x => typeof x === "number" && !isNaN(x);
+
 const intersperse = curryN(2)((delim, coll) =>
   coll.reduce((accum, next, idx) => {
     accum.push(next);
@@ -581,5 +583,6 @@ export {
   mergeArrays,
   usePropAsKey,
   time,
+  isNumber,
   intersperse
 };

--- a/src/app/helpers/functools.js
+++ b/src/app/helpers/functools.js
@@ -535,8 +535,6 @@ function time(arg1, arg2) {
   };
 }
 
-const isNumber = x => typeof x === "number" && !isNaN(x);
-
 const intersperse = curryN(2)((delim, coll) =>
   coll.reduce((accum, next, idx) => {
     accum.push(next);
@@ -583,6 +581,5 @@ export {
   mergeArrays,
   usePropAsKey,
   time,
-  isNumber,
   intersperse
 };


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Das scheint ein [Problem innerhalb von `react-virtualized`](https://github.com/bvaughn/react-virtualized/issues/830) zu sein. Dort wird der Index mit einem "normalen" Nummerncheck überprüft, aber logischerweise ist ja Not-A-Number in JS eine Zahl. Dieses NaN kann in der GRUD statt dem JS-konventionellen -1 auftauchen, wenn der Index einer Spalte nicht gefunden wird.