### PR TITLE
[Bugfix] AC-1029: prevent unwanted column reset

### DIFF
--- a/src/app/components/tableView/TableView.jsx
+++ b/src/app/components/tableView/TableView.jsx
@@ -277,6 +277,7 @@ class TableView extends PureComponent {
     const pasteOriginCell = copySource.cell;
     const pasteOriginCellLang = copySource.langtag;
     const showResetTableViewButton = this.hasResettableChange();
+    const cellUrl = this.getCellUrl();
 
     // const rows = rowsCollection || currentTable.rows || {};
     // pass concatenated row ids on, so children will re-render on sort, filter, add, etc.
@@ -361,7 +362,7 @@ class TableView extends PureComponent {
         {this.renderTableOrSpinner()}
         <JumpSpinner isOpen={!!this.props.showCellJumpOverlay && !filtering} />
         <SearchOverlay isOpen={filtering} />
-        <Redirect to={this.getCellUrl()} />
+        {cellUrl !== location.pathname && <Redirect to={cellUrl} />}
       </div>
     );
   };


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

Die Anpassung sollte den in [AC#1029 ](https://app.activecollab.com/116706/projects/2/tasks/49853) beschriebenen Bug fixen.

Kurze Beschreibung zum Problem:
Durch das Ändern des Wertes einer Cell wird ein Rerender der (gesamten) TableView ausgelöst.
Im Table befindet sich ein Redirect auf die URL der ausgewählten Cell.
Dieser Redirect führt letztendlich zum Reset der Spalteneinstellungen.

Fix:
Der Redirect wird nun nur noch ausgelöst, wenn sich die Cell-URL von der aktuellen URL unterscheidet.
