### PR TITLE
[Bugfix] AC-1005: use disabled column styling on missing edit cell value permission

### DIFF
--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -269,7 +269,7 @@ class Cell extends React.Component {
       selected: selected,
       editing: this.userCanEditValue() && editing,
       "in-selected-row": inSelectedRow,
-      "cell-disabled": cell.isReadOnly,
+      "cell-disabled": cell.isReadOnly || !this.userCanEditValue(),
       "in-multi-selection": inMultiSelection
     });
 


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

-> [#1005: Farbliches hervorheben von Read-Only Spalten](https://app.activecollab.com/116706/projects/2/tasks/46240)
