### PR TITLE
Keep deep-linked row visible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -82,6 +82,10 @@ rules:
     - arrowFunctions: false
   lodash-fp/preferred-alias: off
   lodash-fp/use-fp: warn
+  no-unused-vars:
+    - error
+    - varsIgnorePattern: ^_
+      argsIgnorePattern: ^_
   react/jsx-uses-react: warn
   react/jsx-uses-vars: warn
   react/no-typos: error

--- a/src/app/components/header/filter/FilterPopup.jsx
+++ b/src/app/components/header/filter/FilterPopup.jsx
@@ -545,6 +545,7 @@ class FilterPopup extends React.Component {
           clearFilters={this.clearFilter}
           filters={filters}
           sorting={sorting}
+          langtag={this.props.langtag}
         />
 
         <FilterPresetList

--- a/src/app/components/header/filter/FilterPopup.jsx
+++ b/src/app/components/header/filter/FilterPopup.jsx
@@ -15,6 +15,7 @@ import TableauxConstants, {
 import { either } from "../../../helpers/functools";
 import { getColumnDisplayName } from "../../../helpers/multiLanguage";
 import { canColumnBeSearched } from "../../../helpers/searchFunctions";
+import store from "../../../redux/store";
 import { SortableCellKinds } from "../../table/RowFilters";
 import FilterPopupFooter from "./FilterPopupFooter";
 import FilterPresetList from "./FilterPresetList";
@@ -265,7 +266,9 @@ class FilterPopup extends React.Component {
 
   applyFilters = event => {
     const { filters, sorting } = this.state;
-    const { setRowFilter } = this.props;
+    const { setRowFilter, actions, langtag } = this.props;
+    const tableId = f.prop("tableView.currentTable", store.getState());
+    actions.toggleCellSelection({ select: false, langtag, tableId });
     const colIdToNumber = obj =>
       f.assoc("columnId", parseInt(obj.columnId), obj);
     setRowFilter(

--- a/src/app/components/header/filter/FilterPopupFooter.jsx
+++ b/src/app/components/header/filter/FilterPopupFooter.jsx
@@ -4,11 +4,17 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Actions from "../../../redux/actionCreators";
 
-const FilterPopupFooter = ({ canApplyFilters, applyFilters, clearFilters }) => {
+const FilterPopupFooter = ({
+  canApplyFilters,
+  applyFilters,
+  clearFilters,
+  langtag
+}) => {
   return (
     <div className="description-row">
       <p className="info">
         <DefaultFooter
+          langtag={langtag}
           applyFilters={applyFilters}
           clearFilters={clearFilters}
           canApplyFilters={canApplyFilters}
@@ -18,17 +24,24 @@ const FilterPopupFooter = ({ canApplyFilters, applyFilters, clearFilters }) => {
   );
 };
 
-const DefaultFooter = ({ clearFilters, canApplyFilters, applyFilters }) => {
+const DefaultFooter = ({
+  clearFilters,
+  canApplyFilters,
+  applyFilters,
+  langtag
+}) => {
   const dispatch = useDispatch();
   const tableId = useSelector(state => state.tableView.currentTable);
   const handleApplyFilters = React.useCallback(() => {
     if (canApplyFilters) {
-      dispatch(Actions.toggleCellSelection({ select: false, tableId }));
+      dispatch(
+        Actions.toggleCellSelection({ select: false, tableId, langtag })
+      );
       applyFilters();
     } else {
       clearFilters();
     }
-  });
+  }, [langtag, tableId]);
   return (
     <>
       <button

--- a/src/app/components/header/filter/FilterPopupFooter.jsx
+++ b/src/app/components/header/filter/FilterPopupFooter.jsx
@@ -1,8 +1,7 @@
 import i18n from "i18next";
 import PropTypes from "prop-types";
 import React from "react";
-import { useDispatch, useSelector } from "react-redux";
-import Actions from "../../../redux/actionCreators";
+import { useSelector } from "react-redux";
 
 const FilterPopupFooter = ({
   canApplyFilters,
@@ -30,18 +29,14 @@ const DefaultFooter = ({
   applyFilters,
   langtag
 }) => {
-  const dispatch = useDispatch();
   const tableId = useSelector(state => state.tableView.currentTable);
   const handleApplyFilters = React.useCallback(() => {
     if (canApplyFilters) {
-      dispatch(
-        Actions.toggleCellSelection({ select: false, tableId, langtag })
-      );
       applyFilters();
     } else {
       clearFilters();
     }
-  }, [langtag, tableId]);
+  }, [langtag, tableId, canApplyFilters]);
   return (
     <>
       <button

--- a/src/app/components/header/filter/FilterPopupFooter.jsx
+++ b/src/app/components/header/filter/FilterPopupFooter.jsx
@@ -1,7 +1,8 @@
-import React from "react";
 import i18n from "i18next";
-
 import PropTypes from "prop-types";
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import Actions from "../../../redux/actionCreators";
 
 const FilterPopupFooter = ({ canApplyFilters, applyFilters, clearFilters }) => {
   return (
@@ -18,8 +19,11 @@ const FilterPopupFooter = ({ canApplyFilters, applyFilters, clearFilters }) => {
 };
 
 const DefaultFooter = ({ clearFilters, canApplyFilters, applyFilters }) => {
+  const dispatch = useDispatch();
+  const tableId = useSelector(state => state.tableView.currentTable);
   const handleApplyFilters = React.useCallback(() => {
     if (canApplyFilters) {
+      dispatch(Actions.toggleCellSelection({ select: false, tableId }));
       applyFilters();
     } else {
       clearFilters();

--- a/src/app/components/header/filter/FilterPopupFooter.jsx
+++ b/src/app/components/header/filter/FilterPopupFooter.jsx
@@ -46,6 +46,7 @@ const DefaultFooter = ({
         {i18n.t("filter:button.clearFilter")}
       </button>
       <button
+        disabled={!canApplyFilters}
         className={
           "filter-popup__apply-filters-button " +
           (canApplyFilters ? "" : "neutral")

--- a/src/app/components/table/RowFilters.js
+++ b/src/app/components/table/RowFilters.js
@@ -445,8 +445,8 @@ const mkClosures = (columns, rows, langtag, rowsFilter) => {
     return sortColumnIdx >= 0
       ? f.cond([
           [vals => f.every(isEmpty, vals), f.always(equal)],
-          [([A, _]) => isEmpty(A), f.always(bFirst)], // eslint-disable-line no-unused-vars
-          [([_, B]) => isEmpty(B), f.always(aFirst)], // eslint-disable-line no-unused-vars
+          [([A, _]) => isEmpty(A), f.always(bFirst)],
+          [([_, B]) => isEmpty(B), f.always(aFirst)],
           [
             f.stubTrue,
             ([A, B]) => (f.eq(A, B) ? compareRowIds(a, b) : compareValues(A, B))

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -88,7 +88,7 @@ const addColumnVisibility = (columns = [], visibleColumnIds) =>
   }));
 const maybeAddNullable = (el, coll) =>
   maybe(el)
-    .map(el => [...coll, el])
+    .map(el => [el, ...coll])
     .map(f.uniq)
     .getOrElse(coll);
 const arrayToKey = coll =>

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -34,13 +34,13 @@ const withFiltersAndVisibility = Component => props => {
   );
 
   const visibleRows = useMemo(() => {
-    const filteredRowIDs = maybeAddNullable(
+    const filteredRowIdces = maybeAddNullable(
       selectedCell.rowId
         ? rows?.findIndex(row => row.id === selectedCell.rowId)
         : undefined,
       filterRows(props).visibleRows ?? []
-    );
-    return filteredRowIDs.map(idx => rows[idx]);
+    ).filter(idx => idx >= 0);
+    return filteredRowIdces.map(idx => rows[idx]);
   }, [
     arrayToKey(props.visibleRows),
     rows,

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -34,14 +34,13 @@ const withFiltersAndVisibility = Component => props => {
   );
 
   const visibleRows = useMemo(() => {
-    const filteredRows = filterRows(props).visibleRows;
-    const visibleRowIds = new Set(filteredRows);
-    const mustFilter = props.filters?.length > 0;
-    return mustFilter
-      ? rows?.filter(
-          (row, idx) => row.id === selectedCell.rowId || visibleRowIds.has(idx)
-        ) ?? []
-      : rows;
+    const filteredRowIDs = maybeAddNullable(
+      selectedCell.rowId
+        ? rows?.findIndex(row => row.id === selectedCell.rowId)
+        : undefined,
+      filterRows(props).visibleRows ?? []
+    );
+    return filteredRowIDs.map(idx => rows[idx]);
   }, [
     arrayToKey(props.visibleRows),
     rows,

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -86,10 +86,9 @@ const addColumnVisibility = (columns = [], visibleColumnIds) =>
     ...column,
     visible: shouldColumnBeVisible(column, visibleColumnIds)
   }));
-const maybeAddNullable = (el, coll) =>
-  maybe(el)
-    .map(el => [el, ...coll])
-    .map(f.uniq)
+const maybeAddNullable = (element, coll) =>
+  maybe(element)
+    .map(el => (coll.includes(el) ? coll : [el, ...coll]))
     .getOrElse(coll);
 const arrayToKey = coll =>
   Array.from(coll ?? [])

--- a/src/app/helpers/DisplayValueWorkerControls.js
+++ b/src/app/helpers/DisplayValueWorkerControls.js
@@ -1,0 +1,28 @@
+import f from "lodash/fp";
+
+const shouldStartForTable = ({
+  allDisplayValues,
+  columns,
+  finishedLoading,
+  startedGeneratingDisplayValues,
+  table
+}) =>
+  !f.isEmpty(columns) &&
+  f.isNil(allDisplayValues[table.id]) &&
+  !startedGeneratingDisplayValues &&
+  finishedLoading;
+
+const startForTable = ({
+  actions: { generateDisplayValues },
+  columns,
+  langtag,
+  rows,
+  table
+}) => {
+  generateDisplayValues(rows, columns, table.id, langtag);
+};
+
+export default {
+  shouldStartForTable,
+  startForTable
+};

--- a/src/app/helpers/buildClassName.js
+++ b/src/app/helpers/buildClassName.js
@@ -1,7 +1,7 @@
 export const buildClassName = (base, modifiers = {}, additionals) => {
   const bemModifiers = Object.entries(modifiers || {})
-    .filter(([_, isActive]) => isActive) // eslint-disable-line no-unused-vars
-    .map(([modifier, _]) => `${base}--${modifier}`); // eslint-disable-line no-unused-vars
+    .filter(([_, isActive]) => isActive)
+    .map(([modifier, _]) => `${base}--${modifier}`);
   const additionalsList =
     typeof additionals === "string"
       ? [additionals]

--- a/src/app/redux/redux-helpers.js
+++ b/src/app/redux/redux-helpers.js
@@ -107,8 +107,7 @@ export const getGroupColumn = (data, completeState) =>
 
 export const calcConcatValues = (action, completeState) => {
   const { tableId, columnId, column } = action;
-  // eslint-disable-next-line no-unused-vars
-  const [rowIdx, columnIdx, dvRowIdx] = idsToIndices(action, completeState);
+  const [rowIdx, _columnIdx, dvRowIdx] = idsToIndices(action, completeState);
   const columns = completeState.columns[tableId].data;
   const rows = completeState.rows[tableId].data;
 


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

[AC#1049](https://app.activecollab.com/116706/projects/2?modal=Task-51032-2) - Wenn eine Tabelle mit Deep-Link geöffnet wird und gleichzeitig ein Filter für die Zieltabelle im LocalStorage persistiert ist stellen wir sicher, dass die Zeile des Deep-Links immer sichtbar ist.

Das Verhalten ist jetzt:
- Wenn ein Filter gesetzt ist und eine Zeile per Deep-Link vorausgewählt wird, dann hat der Deep-Link Vorrang, die Zeile ist sichtbar.
- Wenn die Tabelle bereits geladen wurde und wir den Filter per Popup ändern hat die Filterfunktion Vorrang, die ausgewählte Zeile verschwindet, wenn sie nicht Teil des Suchergebnisses ist.

Das hat ein paar Implikationen:
- Wenn die gewählte Zeile nicht Teil des Suchergebnisses ist wird sie vor allen Suchergebnissen angezeigt, um Probleme mit der Sortierung zu vermeiden.
- Wenn ein Filter über das Filterpopup gesetzt wird setzen wir die Zellauswahl zurück, da sonst die aktuelle Zeile immer angezeigt würde.