### PR TITLE
Keep focus when clicking link cells

### DIFF
--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import f from "lodash/fp";
 import PropTypes from "prop-types";
-import React, { useCallback } from "react";
+import React, { createRef, useCallback } from "react";
 import {
   branch,
   compose,
@@ -103,6 +103,7 @@ class Cell extends React.Component {
   constructor(props) {
     super(props);
     this.keyboardShortcuts = {};
+    this.cellRef = createRef(null);
   }
 
   shouldComponentUpdate = nextProps => {
@@ -146,6 +147,11 @@ class Cell extends React.Component {
     })(event);
 
   cellClickedWorker = (event, withRightClick) => {
+    requestAnimationFrame(() => {
+      if (document.activeElement === document.body) {
+        this.cellRef.current?.focus();
+      }
+    });
     const {
       actions,
       cell,
@@ -279,6 +285,7 @@ class Cell extends React.Component {
     // onKeyDown event just for selected components
     return (
       <div
+        ref={this.cellRef}
         style={this.props.style}
         className={cssClass}
         onMouseDown={this.cellClicked}

--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -67,7 +67,9 @@ export default class VirtualTable extends PureComponent {
   }
 
   focusTable = () => {
-    this.virtualTableRef.current.focus();
+    if (document.activeElement !== this.virtualTableRef.current) {
+      requestAnimationFrame(() => this.virtualTableRef.current?.focus());
+    }
   };
 
   setBarOffset = event => {
@@ -78,8 +80,9 @@ export default class VirtualTable extends PureComponent {
     f.propOr({}, "selectedCell.selectedCell", store.getState());
 
   handleScroll = f.debounce(100, () => {
-    if (document.activeElement === document.body)
-      this.virtualTableRef.current?.focus();
+    if (document.activeElement === document.body) {
+      this.focusTable();
+    }
   });
 
   saveColWidths = index => {


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Beim Klick auf eine leere Linkzelle wird der Fokus im Anschluss auf
`document.body` gesetzt.  
Der Grund hierfür ist erst mal nicht ersichtlich, da die Klick-Events in der
`Cell`-Komponente behandelt werden , nicht in den verschiedenen Zelltypen;
ebenso ist die Klickfläche auch bei leeren Linkzellen korrekt.  
Ein Hotfix ist jetzt erst mal Symptombekämpfung indem nach dem Klick der Fokus
wieder auf die angeklickte Zelle gesetzt wird, sollte er verlorengegangen sein.