### PR TITLE
[Bugfix]: Fix cell click handler regressions

### DIFF
--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -202,7 +202,7 @@ class Cell extends React.Component {
         tableId: table.id
       });
     } else if (!withRightClick && this.userCanEditValue() && modifiers.none) {
-      actions.toggleCellEditing({ row, cell, eventKey: event.key });
+      actions.toggleCellEditing({ editing: true });
     }
   };
 

--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -146,19 +146,19 @@ class Cell extends React.Component {
       cell: this.props.cell
     })(event);
 
-  cellClickedWorker = (event, withRightClick) => {
+  cellClickedWorker = event => {
     requestAnimationFrame(() => {
       if (document.activeElement === document.body) {
         this.cellRef.current?.focus();
       }
     });
+
     const {
       actions,
       cell,
       columns,
       editing,
       isExpandedCell,
-      langtag,
       rows,
       selected,
       visibleColumns: visibleColumnIdces
@@ -166,52 +166,62 @@ class Cell extends React.Component {
     if (!editing) {
       event.stopPropagation();
     }
-    const { table, column, row } = cell;
-    const modifiers = getModifiers(event);
 
-    if (withRightClick) {
+    const modifiers = getModifiers(event);
+    this.props.closeCellContextMenu();
+    if (modifiers.none) {
+      actions.clearMultiselect();
+    } else if (!isExpandedCell && modifiers.mod) {
       event.preventDefault();
-      event.stopPropagation();
-      this.openCellContextMenu(event);
-    } else {
-      this.props.closeCellContextMenu();
-      if (modifiers.none) {
-        actions.clearMultiselect();
-      } else if (!isExpandedCell && modifiers.mod) {
-        event.preventDefault();
-        actions.toggleMultiselectCell({ cell });
-      } else if (!isExpandedCell && modifiers.shift) {
-        event.preventDefault();
-        actions.toggleMultiselectArea({
-          cell,
-          columns: visibleColumnIdces.map(idx => ({
-            ...columns[idx],
-            idx
-          })),
-          rows
-        });
-      }
+      actions.toggleMultiselectCell({ cell });
+    } else if (!isExpandedCell && modifiers.shift) {
+      event.preventDefault();
+      actions.toggleMultiselectArea({
+        cell,
+        columns: visibleColumnIdces.map(idx => ({
+          ...columns[idx],
+          idx
+        })),
+        rows
+      });
     }
 
     // we select the cell when clicking or right clicking. Don't jump in edit mode when selected and clicking right
     if (!selected && modifiers.none) {
-      actions.toggleCellSelection({
-        columnId: column.id,
-        rowId: row.id,
-        langtag,
-        tableId: table.id
-      });
-    } else if (!withRightClick && this.userCanEditValue() && modifiers.none) {
+      this.setSelfAsSelected();
+    } else if (this.userCanEditValue() && modifiers.none) {
       actions.toggleCellEditing({ editing: true });
     }
   };
 
+  setSelfAsSelected = () => {
+    const {
+      actions,
+      cell: { column, row, table },
+      langtag
+    } = this.props;
+    actions.toggleCellSelection({
+      columnId: column.id,
+      rowId: row.id,
+      tableId: table.id,
+      langtag
+    });
+  };
+
   rightClicked = event => {
-    this.cellClickedWorker(event, true);
+    event.preventDefault();
+    event.stopPropagation();
+    this.openCellContextMenu(event);
+    if (!this.props.selected) {
+      this.setSelfAsSelected();
+    }
   };
 
   cellClicked = event => {
-    this.cellClickedWorker(event);
+    const withRightClick = event.button > 0;
+    return withRightClick
+      ? this.rightClicked(event)
+      : this.cellClickedWorker(event);
   };
 
   componentDidCatch(error, info) {
@@ -288,7 +298,7 @@ class Cell extends React.Component {
         ref={this.cellRef}
         style={this.props.style}
         className={cssClass}
-        onMouseDown={this.cellClicked}
+        onClick={this.cellClicked}
         onContextMenu={this.rightClicked}
         tabIndex="1"
         onKeyDown={

--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -375,7 +375,11 @@ const RepeaterCell = withHandlers({
     openCellContextMenu({ cell, langtag: f.first(Langtags) })(event);
   }
 })(props => (
-  <div className="cell repeat placeholder" onContextMenu={props.onContextMenu}>
+  <div
+    style={props.style}
+    className="cell repeat placeholder"
+    onContextMenu={props.onContextMenu}
+  >
     —.—
   </div>
 ));

--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -257,6 +257,10 @@ class Cell extends React.Component {
       : canUserChangeCell(cell, langtag);
   }
 
+  stopBubblingUp = event => {
+    event.stopPropagation();
+  };
+
   render() {
     const {
       annotationsOpen,
@@ -302,7 +306,9 @@ class Cell extends React.Component {
         onContextMenu={this.rightClicked}
         tabIndex="1"
         onKeyDown={
-          selected
+          editing
+            ? this.stopBubblingUp
+            : selected
             ? KeyboardShortcutsHelper.onKeyboardShortcut(
                 this.getKeyboardShortcuts
               )

--- a/src/app/components/cells/boolean/BooleanCell.jsx
+++ b/src/app/components/cells/boolean/BooleanCell.jsx
@@ -1,12 +1,19 @@
-import React from "react";
-
 import PropTypes from "prop-types";
-
+import React, { useEffect } from "react";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { isLocked } from "../../../helpers/annotationHelper";
 
 const BooleanCell = props => {
-  const { actions, value, table, row, column, langtag, selected, cell } = props;
+  const {
+    actions,
+    selected,
+    editing,
+    value,
+    row,
+    column,
+    langtag,
+    cell
+  } = props;
 
   const handleEditDone = newValue => {
     const valueToSave = column.multilanguage
@@ -15,27 +22,34 @@ const BooleanCell = props => {
     actions.changeCellValue({
       cell,
       column,
-      tableId: table.id,
-      rowId: row.id,
-      columnId: column.id,
       oldValue: value,
-      newValue: valueToSave,
-      kind: column.kind
+      newValue: valueToSave
     });
   };
+
+  useEffect(() => {
+    if (selected && !editing) {
+      actions.toggleCellEditing({ editing: true });
+    }
+  }, [selected]);
 
   const getCheckboxValue = () => {
     return !!(column.multilanguage ? value[langtag] : value);
   };
 
-  const toggleCheckboxValue = () => {
-    if (!isLocked(row) && canUserChangeCell(cell, langtag)) {
-      selected && handleEditDone(!getCheckboxValue());
+  const handleClick = event => {
+    if (editing) {
+      event.stopPropagation();
+      if (!isLocked(row) && canUserChangeCell(cell, langtag)) {
+        handleEditDone(!getCheckboxValue());
+      }
+    } else {
+      return true;
     }
   };
 
   return (
-    <div className={"cell-content"} onClick={toggleCheckboxValue}>
+    <div className={"cell-content"} onMouseDown={handleClick}>
       <input
         className="checkbox"
         type="checkbox"

--- a/src/app/components/cells/boolean/BooleanCell.jsx
+++ b/src/app/components/cells/boolean/BooleanCell.jsx
@@ -43,13 +43,11 @@ const BooleanCell = props => {
       if (!isLocked(row) && canUserChangeCell(cell, langtag)) {
         handleEditDone(!getCheckboxValue());
       }
-    } else {
-      return true;
     }
   };
 
   return (
-    <div className={"cell-content"} onMouseDown={handleClick}>
+    <div className={"cell-content"} onClick={handleClick}>
       <input
         className="checkbox"
         type="checkbox"

--- a/src/app/components/cells/currency/CurrencyCell.jsx
+++ b/src/app/components/cells/currency/CurrencyCell.jsx
@@ -78,13 +78,17 @@ const CurrencyCell = ({
     });
   }, []);
 
-  const [value, setValue] = useState(cell.value);
+  const [value, setValue] = useState({});
 
   useEffect(() => {
     if (!editing) {
       saveCellValue(value);
     }
   }, [editing, value]);
+  useEffect(() => {
+    // this is the cost of multiple state keeping
+    setValue(cell.value);
+  }, [cell.value]);
 
   const checkPosition = useCallback(
     domNode => {

--- a/src/app/components/cells/currency/CurrencyEditCell.jsx
+++ b/src/app/components/cells/currency/CurrencyEditCell.jsx
@@ -72,7 +72,7 @@ const CurrencyEditCell = ({
     <div
       className="cell-currency-rows"
       ref={container}
-      onMouseDown={evt => {
+      onClick={evt => {
         evt.stopPropagation();
       }}
     >

--- a/src/app/components/cells/currency/CurrencyEditCell.jsx
+++ b/src/app/components/cells/currency/CurrencyEditCell.jsx
@@ -1,6 +1,6 @@
 import f from "lodash/fp";
 import PropTypes from "prop-types";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { canUserChangeCountryTypeCell } from "../../../helpers/accessManagementHelper";
 import { outsideClickEffect } from "../../../helpers/useOutsideClick";
 import {

--- a/src/app/components/cells/currency/CurrencyEditCell.jsx
+++ b/src/app/components/cells/currency/CurrencyEditCell.jsx
@@ -59,12 +59,15 @@ const CurrencyEditCell = ({
     };
   }, []);
 
-  const handleChange = useCallback((country, inputValue) => {
-    onChange({
-      ...value,
-      [country]: fromCurrencyInputValue(inputValue)
-    });
-  }, []);
+  const handleChange = useCallback(
+    (country, inputValue) => {
+      onChange({
+        ...value,
+        [country]: fromCurrencyInputValue(inputValue)
+      });
+    },
+    [value]
+  );
 
   const inputValues = f.mapValues(toCurrencyInputValue, value);
 

--- a/src/app/components/cells/date/DateEditCell.jsx
+++ b/src/app/components/cells/date/DateEditCell.jsx
@@ -30,7 +30,7 @@ const DateEditCell = ({ showTime, value, onChange }) => {
           position: "absolute",
           top: needsShiftUp ? -DATE_PICKER_HEIGHT : "100%"
         }}
-        onMouseDown={evt => {
+        onClick={evt => {
           evt.stopPropagation();
           evt.preventDefault();
         }}

--- a/src/app/components/cells/link/LinkEditCell.jsx
+++ b/src/app/components/cells/link/LinkEditCell.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { isLocked } from "../../../helpers/annotationHelper";
 import { withForeignDisplayValues } from "../../helperComponents/withForeignDisplayValues";
@@ -7,16 +7,18 @@ import LinkLabelCell from "./LinkLabelCell.jsx";
 import { openLinkOverlay } from "./LinkOverlay.jsx";
 
 const LinkEditCell = props => {
-  const { cell, langtag, foreignDisplayValues, value, actions } = props;
+  const {
+    cell,
+    editing,
+    langtag,
+    foreignDisplayValues,
+    value,
+    actions
+  } = props;
 
   const catchScrolling = useCallback(event => {
     event && event.stopPropagation();
   }, []);
-  const openOverlay = useCallback(() => {
-    if (canUserChangeCell(cell, langtag) && !isLocked(cell.row)) {
-      openLinkOverlay({ cell, langtag, actions });
-    }
-  }, [cell.id]);
   const displayValue = foreignDisplayValues || props.displayValue;
 
   const links = value.map((element, index) => (
@@ -30,12 +32,15 @@ const LinkEditCell = props => {
     />
   ));
 
+  useEffect(() => {
+    if (editing && canUserChangeCell(cell, langtag) && !isLocked(cell.row)) {
+      openLinkOverlay({ cell, langtag, actions });
+      actions.toggleCellEditing({ editing: false });
+    }
+  }, [Boolean(editing), isLocked(cell.row)]);
+
   return (
-    <div
-      className={"cell-content"}
-      onScroll={catchScrolling}
-      onMouseDown={openOverlay}
-    >
+    <div className={"cell-content"} onScroll={catchScrolling}>
       {canUserChangeCell(cell, langtag)
         ? [
             ...links,

--- a/src/app/components/cells/link/LinkOverlay.jsx
+++ b/src/app/components/cells/link/LinkOverlay.jsx
@@ -271,6 +271,7 @@ class LinkOverlay extends PureComponent {
       value,
       rowResults,
       actions,
+      cell,
       cell: { table, row, column }
     } = this.props;
     const linkedItems = rowResults.linked;

--- a/src/app/components/cells/text/ExpandButton.jsx
+++ b/src/app/components/cells/text/ExpandButton.jsx
@@ -1,22 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withHandlers, pure, compose } from "recompose";
 
-const withFunctionality = compose(
-  withHandlers({
-    onClick: props => event => props.onTrigger(event)
-  }),
-  pure
-);
-
-const ExpandButton = props => (
-  <button className="expand" onClick={props.onClick}>
-    <span className="fa fa-expand" />
-  </button>
-);
+const ExpandButton = props => {
+  return (
+    <button className="expand" onMouseDown={props.onTrigger}>
+      <span className="fa fa-expand" />
+    </button>
+  );
+};
 
 ExpandButton.propTypes = {
   onTrigger: PropTypes.func.isRequired
 };
 
-export default withFunctionality(ExpandButton);
+export default ExpandButton;

--- a/src/app/components/cells/text/TextCell.jsx
+++ b/src/app/components/cells/text/TextCell.jsx
@@ -1,27 +1,54 @@
-import "../../../../scss/main.scss";
-
-import { withHandlers } from "recompose";
-import React from "react";
 import f from "lodash/fp";
-
+import React, { useEffect } from "react";
+import "../../../../scss/main.scss";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { getTableDisplayName } from "../../../helpers/multiLanguage";
-import ExpandButton from "./ExpandButton.jsx";
-import Header from "../../overlay/Header";
 import MarkdownEditor from "../../markdownEditor/MarkdownEditor";
+import Header from "../../overlay/Header";
+import ExpandButton from "./ExpandButton.jsx";
 import TextEditOverlay from "./TextEditOverlay";
 
 const TextCell = props => {
-  const { langtag, displayValue, selected, openEditOverlay } = props;
+  const {
+    actions,
+    cell,
+    table,
+    langtag,
+    displayValue,
+    editing,
+    selected,
+    value
+  } = props;
   const isMultiLine = f.contains("\n", displayValue[langtag]);
 
+  useEffect(() => {
+    if (editing) {
+      const editable = canUserChangeCell(cell, langtag);
+      const context = getTableDisplayName(table, langtag);
+      const isRichText = cell.column.kind === "richtext";
+
+      actions.openOverlay({
+        head: <Header context={context} langtag={langtag} />,
+        body: isRichText ? (
+          <MarkdownEditor {...props} readOnly={editable} />
+        ) : (
+          <TextEditOverlay {...props} readOnly={!editable} />
+        ),
+        title: cell,
+        type: "full-height",
+        classes: isRichText ? "text-editor-overlay" : ""
+      });
+    }
+  }, [editing, value]);
+
+  const handleSetEditing = () => {
+    actions.toggleCellEditing({ editing: true });
+  };
+
   return (
-    <div
-      className={`cell-content ${isMultiLine ? "is-multiline" : ""}`}
-      onClick={openEditOverlay}
-    >
+    <div className={`cell-content ${isMultiLine ? "is-multiline" : ""}`}>
       <div>{displayValue[langtag].split("\n")[0]}</div>
-      {selected ? <ExpandButton onTrigger={openEditOverlay} /> : null}
+      {selected ? <ExpandButton onTrigger={handleSetEditing} /> : null}
       {isMultiLine ? (
         <i className="fa fa-paragraph multiline-indicator" />
       ) : null}
@@ -29,42 +56,4 @@ const TextCell = props => {
   );
 };
 
-const enhance = withHandlers({
-  openEditOverlay: props => event => {
-    const { actions, selected, cell, table, langtag, value } = props;
-
-    if (selected) {
-      event && event.stopPropagation();
-
-      const context = getTableDisplayName(table, langtag);
-
-      const isRichText = cell.column.kind === "richtext";
-
-      actions.openOverlay({
-        head: <Header context={context} langtag={langtag} />,
-        body: isRichText ? (
-          <MarkdownEditor
-            actions={actions}
-            value={value}
-            langtag={langtag}
-            cell={cell}
-            readOnly={!canUserChangeCell(cell, langtag)}
-          />
-        ) : (
-          <TextEditOverlay
-            actions={actions}
-            value={value}
-            langtag={langtag}
-            cell={cell}
-            readOnly={!canUserChangeCell(cell, langtag)}
-          />
-        ),
-        title: cell,
-        type: "full-height",
-        classes: isRichText ? "text-editor-overlay" : ""
-      });
-    }
-  }
-});
-
-export default enhance(TextCell);
+export default TextCell;

--- a/src/app/components/cells/text/TextCell.jsx
+++ b/src/app/components/cells/text/TextCell.jsx
@@ -7,6 +7,7 @@ import MarkdownEditor from "../../markdownEditor/MarkdownEditor";
 import Header from "../../overlay/Header";
 import ExpandButton from "./ExpandButton.jsx";
 import TextEditOverlay from "./TextEditOverlay";
+import { Langtags } from "../../../constants/TableauxConstants";
 
 const TextCell = props => {
   const {
@@ -30,7 +31,7 @@ const TextCell = props => {
       actions.openOverlay({
         head: <Header context={context} langtag={langtag} />,
         body: isRichText ? (
-          <MarkdownEditor {...props} readOnly={editable} />
+          <MarkdownEditor {...props} readOnly={!editable} />
         ) : (
           <TextEditOverlay {...props} readOnly={!editable} />
         ),
@@ -38,6 +39,7 @@ const TextCell = props => {
         type: "full-height",
         classes: isRichText ? "text-editor-overlay" : ""
       });
+      actions.toggleCellEditing({ editing: false });
     }
   }, [editing, value]);
 

--- a/src/app/components/cells/text/TextCell.jsx
+++ b/src/app/components/cells/text/TextCell.jsx
@@ -7,7 +7,6 @@ import MarkdownEditor from "../../markdownEditor/MarkdownEditor";
 import Header from "../../overlay/Header";
 import ExpandButton from "./ExpandButton.jsx";
 import TextEditOverlay from "./TextEditOverlay";
-import { Langtags } from "../../../constants/TableauxConstants";
 
 const TextCell = props => {
   const {

--- a/src/app/components/cells/text/TextEditOverlay.jsx
+++ b/src/app/components/cells/text/TextEditOverlay.jsx
@@ -105,6 +105,7 @@ const enhance = compose(
   lifecycle({
     componentWillUnmount() {
       this.props.saveEdits();
+      this.props.actions.toggleCellEditing({ editing: false });
     }
   })
 );

--- a/src/app/components/cells/text/TextEditOverlay.jsx
+++ b/src/app/components/cells/text/TextEditOverlay.jsx
@@ -99,7 +99,6 @@ const enhance = compose(
           rowId: row.id,
           cell
         });
-        actions.toggleCellEditing({ editing: false });
       }
     }
   ),

--- a/src/app/components/cells/text/TextEditOverlay.jsx
+++ b/src/app/components/cells/text/TextEditOverlay.jsx
@@ -99,13 +99,13 @@ const enhance = compose(
           rowId: row.id,
           cell
         });
+        actions.toggleCellEditing({ editing: false });
       }
     }
   ),
   lifecycle({
     componentWillUnmount() {
       this.props.saveEdits();
-      this.props.actions.toggleCellEditing({ editing: false });
     }
   })
 );

--- a/src/app/components/contextMenu/RowContextMenu.jsx
+++ b/src/app/components/contextMenu/RowContextMenu.jsx
@@ -153,6 +153,7 @@ class RowContextMenu extends React.Component {
       : f.get(["cell", "value"], copySource);
     return table.type !== "settings" &&
       copySource &&
+      canUserChangeCell(cell, langtag) &&
       !f.isEmpty(copySource) &&
       canConvert(copySource.cell.kind, cell.kind) &&
       !f.eq(cell.id, copySource.cell.id) &&

--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -320,7 +320,7 @@ export default class VirtualTable extends PureComponent {
 
     return (
       <div className="cell-stack">
-        {Langtags.map(langtag => {
+        {Langtags.map((langtag, idx) => {
           const isPrimaryLang = langtag === f.first(Langtags);
           const displayValue = this.getDisplayValueWithFallback(
             rowIndex,
@@ -328,6 +328,8 @@ export default class VirtualTable extends PureComponent {
             column,
             cell.value
           );
+
+          const style = { position: "absolute", top: `${idx * ROW_HEIGHT}px` };
 
           return (
             <Cell
@@ -354,6 +356,7 @@ export default class VirtualTable extends PureComponent {
               value={cell.value}
               visibleColumns={this.props.visibleColumnOrdering}
               width={width}
+              style={style}
             />
           );
         })}

--- a/src/app/helpers/accessManagementHelper.js
+++ b/src/app/helpers/accessManagementHelper.js
@@ -1,13 +1,13 @@
 import f from "lodash/fp";
-
 import {
-  Langtags,
   ImmutableColumnKinds,
+  Langtags,
   LanguageType
 } from "../constants/TableauxConstants";
-import { memoizeWith, unless } from "./functools";
-import { noAuthNeeded } from "./authenticate";
 import store from "../redux/store";
+import { noAuthNeeded } from "./authenticate";
+import { memoizeWith, unless } from "./functools";
+import { getCountryOfLangtag } from "./multiLanguage";
 
 // Table data editing permissions
 
@@ -68,13 +68,16 @@ const getPermission = pathToPermission =>
   );
 
 // (cell | {tableId: number, columnId: number}) -> (langtag | nil) -> boolean
-export const canUserChangeCell = f.curry((cellInfo, langtag) => {
-  const { kind } = cellInfo;
-  const editCellValue = getPermission(["column", "editCellValue"])(cellInfo);
+export const canUserChangeCell = f.curry((cell, langtag) => {
+  const { kind } = cell;
+  const editCellValue = getPermission(["column", "editCellValue"])(cell);
+  const language = f.propEq("column.languageType", LanguageType.country)(cell)
+    ? getCountryOfLangtag(langtag)
+    : langtag;
 
   const allowed = f.isBoolean(editCellValue)
     ? editCellValue
-    : f.isPlainObject(editCellValue) && editCellValue[langtag];
+    : f.isPlainObject(editCellValue) && editCellValue[language];
 
   return !f.contains(kind, ImmutableColumnKinds) && (allowed || noAuthNeeded()); // this special case is not caught by ALLOW_ANYTHING
 });


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

- Text-, Richtext- und Boolean-Zellen haben bei Linksklick sofort zum
  Editiermodus gewechselt.
- Fokussierte Text-, Richtext-, Link- und Attachment-Zellen haben bei
  Rechtsklick zum Editiermodus gewechselt, anstatt das Kontextmenü anzuzeigen.
- Zell-Klickhandler für Links- und Rechtsklick waren stark vermischt ->
  Refaktor, Funktionalitäten getrennt
- Durch die vermischten Funktionalitäten mussten wir anfangen, höhere Priorität
  zu simulieren indem wir statt auf `click` schon auf `mousedown` gehört haben,
  das konnte wieder zurückgesetzt werden