### PR TITLE
AC#1061: Prevent text selection on shift-click

### DIFF
--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -263,7 +263,7 @@ class Cell extends React.Component {
 
   preventTextRangeSelection = event => {
     const modifiers = getModifiers(event);
-    if (modifiers.shift) {
+    if (modifiers.shift || modifiers.mod) {
       event.preventDefault();
     }
   };

--- a/src/app/components/cells/Cell.jsx
+++ b/src/app/components/cells/Cell.jsx
@@ -261,6 +261,13 @@ class Cell extends React.Component {
     event.stopPropagation();
   };
 
+  preventTextRangeSelection = event => {
+    const modifiers = getModifiers(event);
+    if (modifiers.shift) {
+      event.preventDefault();
+    }
+  };
+
   render() {
     const {
       annotationsOpen,
@@ -303,6 +310,7 @@ class Cell extends React.Component {
         style={this.props.style}
         className={cssClass}
         onClick={this.cellClicked}
+        onMouseDown={this.preventTextRangeSelection}
         onContextMenu={this.rightClicked}
         tabIndex="1"
         onKeyDown={


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Das verbietet allerdings generell, in den Zellen Shift-Multiselect zu machen.  
Eine Alternative wäre es, den ausgewählten Range dann zu löschen, wenn es sich um einen reinen Zell-Multiselekt handelt, das hätte allerdings den Nachteil, dass die Textselektion kurz hässlich aufflackern würde.

Meinungen dazu?