### PR TITLE
Move and separate destructive row context menu actions

### DIFF
--- a/src/app/components/contextMenu/RowContextMenu.jsx
+++ b/src/app/components/contextMenu/RowContextMenu.jsx
@@ -355,6 +355,14 @@ class RowContextMenu extends React.Component {
       closeRowContextMenu
     } = this;
 
+    const isSettingsTable = table.type === "settings";
+
+    const isDeletingRowAllowed =
+      !isSettingsTable && canUserDeleteRow({ table }) && !final;
+
+    const isDuplicatingRowAllowed =
+      !isSettingsTable && canUserCreateRow({ table });
+
     return (
       <div className="prevent-scroll" onClick={closeRowContextMenu}>
         <GenericContextMenu
@@ -403,17 +411,18 @@ class RowContextMenu extends React.Component {
           {this.props.table.type === "settings"
             ? ""
             : this.mkItem(showEntityView, "show_entity_view", "server")}
-          {this.props.table.type === "settings" || !canUserCreateRow({ table })
-            ? ""
-            : this.mkItem(duplicateRow, "duplicate_row", "clone")}
-          {this.props.table.type === "settings" ||
-          !canUserDeleteRow({ table }) ||
-          final
-            ? ""
-            : this.mkItem(deleteRow, "delete_row", "trash-o")}
           {this.mkItem(showDependency, "show_dependency", "code-fork")}
           {this.mkItem(showTranslations, "show_translation", "flag")}
           {this.setFinalItem()}
+          {isDeletingRowAllowed || isDuplicatingRowAllowed ? (
+            <div className="separator--internal" />
+          ) : null}
+          {isDuplicatingRowAllowed
+            ? this.mkItem(duplicateRow, "duplicate_row", "clone")
+            : null}
+          {isDeletingRowAllowed
+            ? this.mkItem(deleteRow, "delete_row", "trash-o")
+            : null}
         </GenericContextMenu>
       </div>
     );

--- a/src/scss/contextMenu.scss
+++ b/src/scss/contextMenu.scss
@@ -7,7 +7,8 @@
   border-radius: 4px;
   padding: 20px 0;
 
-  button, a {
+  button,
+  a {
     box-sizing: border-box;
     width: 100%;
     display: flex;
@@ -20,17 +21,17 @@
       position: relative;
 
       &.dot.translation {
-        @include status-dot($color-needs-translation, $color-overlay-header)
+        @include status-dot($color-needs-translation, $color-overlay-header);
       }
-      
+
       &.dot.important {
         @include status-dot($color-important, $color-overlay-header);
       }
-      
+
       &.dot.check-me {
         @include status-dot($color-checkme, $color-overlay-header);
       }
-      
+
       &.dot.postpone {
         @include status-dot($color-postpone, $color-overlay-header);
       }
@@ -44,7 +45,10 @@
       background-color: $color-hover-dark;
 
       .dot.translation {
-        @include status-dot-hovered($color-needs-translation, $color-hover-dark)
+        @include status-dot-hovered(
+          $color-needs-translation,
+          $color-hover-dark
+        );
       }
 
       .dot.important {
@@ -83,16 +87,16 @@
     }
   }
 }
-  .prevent-scroll {
-    left:0px;
-    right:0px;
-    top:0px;
-    bottom:0px;
-    height: 100%;
-    width: 100%;
-    position: absolute;
-    z-index:2;
-  }
+.prevent-scroll {
+  left: 0px;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  z-index: 2;
+}
 
 .column-head .context-menu {
   @include context-menu-look();

--- a/src/scss/contextMenu.scss
+++ b/src/scss/contextMenu.scss
@@ -82,7 +82,7 @@
     &--internal {
       padding: 0;
       border-top: 1px solid transparentize($color-text-medium-grey, 0.5);
-      margin: 8px 0;
+      margin: 8px 25px;
       box-sizing: border-box;
     }
   }

--- a/src/scss/contextMenu.scss
+++ b/src/scss/contextMenu.scss
@@ -74,6 +74,13 @@
       padding-top: 25px;
       margin-top: 15px;
     }
+
+    &--internal {
+      padding: 0;
+      border-top: 1px solid transparentize($color-text-medium-grey, 0.5);
+      margin: 8px 0;
+      box-sizing: border-box;
+    }
   }
 }
   .prevent-scroll {


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

Der Auto-Linter hat im SCSS zugeschlagen und u.A. mindetens ein fehlendes Semikolon nachgetragen. Mit "hide whitespace" sind die Changes minimal.