### PR TITLE
Re-calculate display values after loading archived data

### DIFF
--- a/src/app/helpers/DisplayValueWorkerControls.js
+++ b/src/app/helpers/DisplayValueWorkerControls.js
@@ -5,10 +5,12 @@ const shouldStartForTable = ({
   columns,
   finishedLoading,
   startedGeneratingDisplayValues,
-  table
+  table,
+  rows
 }) =>
   !f.isEmpty(columns) &&
-  f.isNil(allDisplayValues[table.id]) &&
+  (f.isNil(allDisplayValues[table.id]) ||
+    allDisplayValues[table.id].length < rows.length) &&
   !startedGeneratingDisplayValues &&
   finishedLoading;
 


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Hier scheint das Problem beim Filtern zu sein, dass die DisplayValues für die
archivierten Rows nicht nachgeneriert werden, dadurch greifen die Suchfunktionen
nicht.