### PR TITLE
Add OR filtering by pipe `|`

### DIFF
--- a/src/app/components/header/filter/FilterRow.jsx
+++ b/src/app/components/header/filter/FilterRow.jsx
@@ -105,8 +105,19 @@ const ValueInput = ({ column, mode, value, onChange }) => {
   );
   const disabled = !column || !mode;
   const filterMode = RowFilters.ModesForKind[(column?.kind)];
-  const handleSetEventValue = evt =>
-    void onChange(filterMode?.readValue(evt.target.value));
+  const handleSetEventValue = evt => {
+    const input = evt.target.value;
+    const endChar = input.length > 1 && input.endsWith("|") ? "|" : "";
+    const newValue =
+      input
+        .replace(/[|]+/g, "|")
+        .split(/[|]+/)
+        .filter(Boolean)
+        .map(filterMode?.readValue)
+        .join("|") + endChar;
+    onChange(newValue);
+  };
+
   return RowFilters.needsFilterValue(column?.kind, mode) ? (
     <input
       className="filter-input"

--- a/src/app/components/header/filter/helpers.js
+++ b/src/app/components/header/filter/helpers.js
@@ -101,6 +101,11 @@ export const fromCombinedFilter = (columns, langtag) => {
       rest.forEach(next =>
         filterToSettingM(next, rowFilters, annotationFilters)
       );
+    } else if (kind === "or") {
+      const values = rest.flatMap(args => args.slice(-1));
+      const setting = rest[0].slice(0, -1);
+      const multiFilter = [...setting, values.join("|")];
+      filterToSettingM(multiFilter, rowFilters, annotationFilters);
     } else {
       const [templateName] =
         Object.entries(templates).find(([_, setting]) =>


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Hier noch der fehlende Teil in der Frontendsuche, der in den Filterbäumen beim Einlesen eines Pipe-Zeichens im Value OR-verknüpfte Branches hinzufügt bzw. für die Anzeige die Einzelwerte dieser Branches wieder mit Pipe konkateniert.

Es ist keinerlei komplexere Logik impliziert, die prüfen würde ob ein "Oder" an dieser Stelle wirklich eine sinnvolle Suche erzeugt. Man kann beispielsweise "Gewicht kleiner als '100|80'" eingeben. Suchinputs werden einfach geparst und in dem Fall zwei Suchen erzeugt, die dann "Gewicht kleiner als 100" OR "Gewicht kleiner 80" auswerten.