### PR TITLE
Fix some column visibility issues

### DIFF
--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo } from "react";
 import { useSelector } from "react-redux";
 import { SortDirection } from "react-virtualized";
 import { ShowArchived } from "../../archivedRows";
-import { ColumnKinds } from "../../constants/TableauxConstants";
+import { findGroupMemberIds } from "../../helpers/columnHelper";
 import DVWorkerCtl from "../../helpers/DisplayValueWorkerControls";
 import { selectShowArchivedState } from "../../redux/reducers/tableView";
 import RowFilters, { filterStateful, sortRows } from "../../RowFilters";
@@ -44,7 +44,7 @@ const withFiltersAndVisibility = Component => props => {
       ? f.compose(
           ([rs, ids]) => [
             applyRowOrdering(rs),
-            ids.difference(getHiddenGroupColumnIDs(columns))
+            ids.difference(findGroupMemberIds(columns))
           ],
           filterRows
         )(ctx, { filters, table, store, selectedRowId: selectedCell?.rowId })
@@ -106,13 +106,6 @@ const withFiltersAndVisibility = Component => props => {
     return <Component {...{ ...props, canRenderTable, showCellJumpOverlay }} />;
   }
 };
-
-const getHiddenGroupColumnIDs = columns =>
-  new Set(
-    columns
-      .filter(col => col.kind === ColumnKinds.group && !col.showMemberColumns)
-      .flatMap(col => col.groups.map(group => group.id))
-  );
 
 const getSorting = (sorting = {}, defaultIsDesc = false) =>
   !f.isEmpty(sorting)

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -19,7 +19,8 @@ const withFiltersAndVisibility = Component => props => {
     columnOrdering = [],
     filters = [],
     langtag,
-    table
+    table,
+    visibleColumns: customVisibleColumnIdces
   } = props;
   const shouldLaunchDisplayValueWorker = DVWorkerCtl.shouldStartForTable(props);
   useEffect(() => {
@@ -43,7 +44,7 @@ const withFiltersAndVisibility = Component => props => {
       ? f.compose(
           ([rs, ids]) => [
             applyRowOrdering(rs),
-            ids.difference(getGroupColumnIds(columns))
+            ids.difference(getHiddenGroupColumnIDs(columns))
           ],
           filterRows
         )(ctx, { filters, table, store, selectedRowId: selectedCell?.rowId })
@@ -56,12 +57,15 @@ const withFiltersAndVisibility = Component => props => {
     sorting,
     canRenderContent,
     workerStillRunning,
-    langtag
+    langtag,
+    customVisibleColumnIdces.join(",")
   ]);
+  const customVisibleColumnIDs = new Set(customVisibleColumnIdces);
   const columnsWithVisibility = columns.map((col, idx) => ({
     ...col,
     visible:
       idx === 0 ||
+      customVisibleColumnIDs.has(idx) ||
       col.id === selectedCell?.columnId ||
       visibleColumnIDs.has(col.id)
   }));
@@ -103,10 +107,10 @@ const withFiltersAndVisibility = Component => props => {
   }
 };
 
-const getGroupColumnIds = columns =>
+const getHiddenGroupColumnIDs = columns =>
   new Set(
     columns
-      .filter(col => col.kind === ColumnKinds.group)
+      .filter(col => col.kind === ColumnKinds.group && !col.showMemberColumns)
       .flatMap(col => col.groups.map(group => group.id))
   );
 

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -20,7 +20,7 @@ const withFiltersAndVisibility = Component => props => {
     filters = [],
     langtag,
     table,
-    visibleColumns: customVisibleColumnIdces
+    visibleColumns: customVisibleColumnIDs
   } = props;
   const shouldLaunchDisplayValueWorker = DVWorkerCtl.shouldStartForTable(props);
   useEffect(() => {
@@ -58,14 +58,14 @@ const withFiltersAndVisibility = Component => props => {
     canRenderContent,
     workerStillRunning,
     langtag,
-    customVisibleColumnIdces.join(",")
+    customVisibleColumnIDs.join(",")
   ]);
-  const customVisibleColumnIDs = new Set(customVisibleColumnIdces);
+  const customVisibleColumnIDSet = new Set(customVisibleColumnIDs);
   const columnsWithVisibility = columns.map((col, idx) => ({
     ...col,
     visible:
       idx === 0 ||
-      customVisibleColumnIDs.has(idx) ||
+      customVisibleColumnIDSet.has(idx) ||
       col.id === selectedCell?.columnId ||
       visibleColumnIDs.has(col.id)
   }));

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -9,6 +9,9 @@ import DVWorkerCtl from "../../helpers/DisplayValueWorkerControls";
 import { selectShowArchivedState } from "../../redux/reducers/tableView";
 import RowFilters, { filterStateful, sortRows } from "../../RowFilters";
 
+// Use fast, native set difference when available, fall back for Safari and
+// older browsers.
+// https://caniuse.com/mdn-javascript_builtins_set_difference
 const setDifference = (a, b) =>
   typeof Set.prototype.difference === "function"
     ? a.difference(b)

--- a/src/app/components/tableView/applyFiltersAndVisibility.jsx
+++ b/src/app/components/tableView/applyFiltersAndVisibility.jsx
@@ -9,6 +9,11 @@ import DVWorkerCtl from "../../helpers/DisplayValueWorkerControls";
 import { selectShowArchivedState } from "../../redux/reducers/tableView";
 import RowFilters, { filterStateful, sortRows } from "../../RowFilters";
 
+const setDifference = (a, b) =>
+  typeof Set.prototype.difference === "function"
+    ? a.difference(b)
+    : new Set(f.difference(Array.from(a), Array.from(b)));
+
 const withFiltersAndVisibility = Component => props => {
   const store = useSelector(x => x);
   const showArchived = selectShowArchivedState(store);
@@ -44,7 +49,7 @@ const withFiltersAndVisibility = Component => props => {
       ? f.compose(
           ([rs, ids]) => [
             applyRowOrdering(rs),
-            ids.difference(findGroupMemberIds(columns))
+            setDifference(ids, findGroupMemberIds(columns))
           ],
           filterRows
         )(ctx, { filters, table, store, selectedRowId: selectedCell?.rowId })
@@ -60,15 +65,16 @@ const withFiltersAndVisibility = Component => props => {
     langtag,
     customVisibleColumnIDs.join(",")
   ]);
-  const customVisibleColumnIDSet = new Set(customVisibleColumnIDs);
-  const columnsWithVisibility = columns.map((col, idx) => ({
-    ...col,
-    visible:
+  const columnsWithVisibility = columns.map((col, idx) => {
+    const visible =
       idx === 0 ||
-      customVisibleColumnIDSet.has(idx) ||
       col.id === selectedCell?.columnId ||
-      visibleColumnIDs.has(col.id)
-  }));
+      visibleColumnIDs.has(col.id);
+    return {
+      ...col,
+      visible
+    };
+  });
   const columnIdxLookup = (columns || []).reduce((acc, col, idx) => {
     acc[col.id] = idx;
     return acc;


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

- Einblendbare Grupppenspalten sind wieder einblendbar
- Normale Suche dominiert nicht mehr die Spaltensichtbarkeit
- Suche nach Annotations/"irgendeine Spalte enthält" fixiert Spalten mit Treffern als sichtbar, andere Spalten können weiterhin vom User ein-/ausgeblendet werden

**Edit:** Nein, es ist nicht ohne erheblichen weiteren Aufwand möglich, visuelles Feedback zu fixierten Spalten anzuzeigen.