### PR TITLE
AC#1142/Fix Frontend Crash

### DIFF
--- a/src/app/redux/reducers/tableView.js
+++ b/src/app/redux/reducers/tableView.js
@@ -164,25 +164,35 @@ const toggleExpandedRow = (state, action) => {
   );
 };
 
-const setInitialVisibleColumns = (action, completeState) => state =>
-  f.get(["globalSettings", "columnsReset"], completeState) ||
-  f.isEmpty(f.get("visibleColumns", state))
-    ? f.flow(
-        f.prop(["result", "columns"]),
-        f.map("id"),
-        ids => f.assoc("visibleColumns")(ids)(state)
-      )(action)
-    : state;
+const setInitialVisibleColumns = (action, completeState) => state => {
+  const isCurrentTable = state.currentTable === action.tableId;
+  const isReset = f.get(["globalSettings", "columnsReset"], completeState);
+  const isVisibleColumnsEmpty = f.isEmpty(f.get("visibleColumns", state));
 
-const setInitialColumnOrdering = (action, completeState) => state =>
-  f.get(["globalSettings", "columnsReset"], completeState) ||
-  f.isEmpty(f.get("columnOrdering", state))
-    ? f.flow(
-        f.prop(["result", "columns"]),
-        mapIndexed(({ id }, idx) => ({ id, idx })),
-        ids => f.assoc("columnOrdering", ids, state)
-      )(action)
-    : state;
+  if ((isReset || isVisibleColumnsEmpty) && isCurrentTable) {
+    const columns = f.get(["result", "columns"], action);
+    const visibleColumns = f.map("id", columns);
+
+    return { ...state, visibleColumns };
+  }
+
+  return state;
+};
+
+const setInitialColumnOrdering = (action, completeState) => state => {
+  const isCurrentTable = state.currentTable === action.tableId;
+  const isReset = f.get(["globalSettings", "columnsReset"], completeState);
+  const isColumnOrderingEmpty = f.isEmpty(f.get("columnOrdering", state));
+
+  if ((isReset || isColumnOrderingEmpty) && isCurrentTable) {
+    const columns = f.get(["result", "columns"], action);
+    const columnOrdering = mapIndexed(({ id }, idx) => ({ id, idx }))(columns);
+
+    return { ...state, columnOrdering };
+  }
+
+  return state;
+};
 
 const displayValueSelector = ({ tableId, dvRowIdx, columnIdx }) => [
   "displayValues",


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Mit aktivierter User-Einstellung "Spaltenansicht automatisch zurücksetzen"

<img width="505" alt="Bildschirmfoto 2025-02-12 um 11 51 53" src="https://github.com/user-attachments/assets/0b8d3044-2a24-4246-933d-90e45d46eda2" />

konnte es dazu kommen, dass die Sortierung und Sichtbarkeit der Spalten falsch initialisiert wurde.
Mit der Änderung im PR wird sichergestellt, dass für die initiale Sortierung und Sichtbarkeit die richtigen Spaltendaten verwendet werden.