### PR TITLE
AC-1128: Fix translation-needed-for filter in single column tables

### DIFF
--- a/src/app/RowFilters/Annotation.js
+++ b/src/app/RowFilters/Annotation.js
@@ -48,6 +48,6 @@ export default {
         visibleColumns.add(columns[idx]?.id);
         return true;
       } else return found;
-    });
+    }, false);
   }
 };


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

In Tabellen mit nur einer Spalte ist der Default-Startwert für den Reduce nicht falsy.