### PR TITLE
AC#1158/fix permission check for currency view

### DIFF
--- a/src/app/components/entityView/RowView.jsx
+++ b/src/app/components/entityView/RowView.jsx
@@ -7,7 +7,10 @@ import {
   ColumnKinds,
   AnnotationConfigs
 } from "../../constants/TableauxConstants";
-import * as Access from "../../helpers/accessManagementHelper";
+import {
+  canUserChangeAnyCountryTypeCell,
+  canUserChangeCell
+} from "../../helpers/accessManagementHelper";
 import {
   getAnnotationByName,
   getAnnotationColor,
@@ -16,10 +19,7 @@ import {
   isTranslationNeeded
 } from "../../helpers/annotationHelper";
 import { unless } from "../../helpers/functools";
-import {
-  getCountryOfLangtag,
-  retrieveTranslation
-} from "../../helpers/multiLanguage";
+import { retrieveTranslation } from "../../helpers/multiLanguage";
 import AnnotationBadge from "../annotation/AnnotationBadge";
 import Spinner from "../header/Spinner";
 import { connectOverlayToCellValue } from "../helperComponents/connectOverlayToCellHOC";
@@ -63,13 +63,16 @@ class View extends PureComponent {
   componentDidCatch() {}
 
   canEditValue = theoretically => {
-    const { cell, langtag } = this.props;
-    const langtagOrCountry = f.propEq(["column", "languageType"], "country")(
-      cell
-    )
-      ? getCountryOfLangtag(langtag)
-      : langtag;
-    const canEditUnlocked = Access.canUserChangeCell(cell, langtagOrCountry);
+    const {
+      cell,
+      cell: { column },
+      langtag
+    } = this.props;
+    const canEditUnlocked =
+      column.multilanguage && column.languageType === "country"
+        ? canUserChangeAnyCountryTypeCell(cell)
+        : canUserChangeCell(cell, langtag);
+
     return theoretically
       ? canEditUnlocked
       : canEditUnlocked &&

--- a/src/scss/entityView/entityView.scss
+++ b/src/scss/entityView/entityView.scss
@@ -134,6 +134,10 @@
     border: none;
     border-color: transparent;
 
+    &.disabled {
+      cursor: not-allowed;
+    }
+
     &.not-set {
       .currency-string,
       .langtag-label,


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

Anmerkung:
In der EntityView wurde für Currency-Spalten ein falscher Permission-Check durchgeführt (auf Basis der eingestellten Sprache). Dieser falsche Check wurde entsprechend dem [Permission-Check in der Cell-Komponente](https://github.com/campudus/tableaux-frontend/blob/master/src/app/components/cells/Cell.jsx#L217) angepasst.
