### PR TITLE
AC#1152/add formatPattern for concat column

### DIFF
--- a/src/app/components/cells/identifier/IdentifierCell.jsx
+++ b/src/app/components/cells/identifier/IdentifierCell.jsx
@@ -39,7 +39,8 @@ const IdentifierCell = props => {
   return (
     <div className={className} onClick={openEditor}>
       {cell.column.kind === ColumnKinds.concat &&
-      !f.isEmpty(foreignDisplayValues)
+      !f.isEmpty(foreignDisplayValues) &&
+      !cell.column.formatPattern
         ? foreignDisplayValues
         : displayValue[langtag]}
     </div>

--- a/src/app/helpers/getDisplayValue.js
+++ b/src/app/helpers/getDisplayValue.js
@@ -203,10 +203,7 @@ const format = f.curryN(2)((column, displayValue) => {
     // replace all occurences of {{n+1}} with displayValue[n];
     // Because the formatPatterns consists of absolute columnId we first have to map index to columnId
     const applyFormat = (result, dVal, idx) => {
-      const colIdx = f.flow(
-        f.map("id"),
-        f.nth(idx)
-      )(innerColumns);
+      const colId = innerColumns[idx]?.id;
 
       // Boolean columns are a special case; falsy bool values deliver an empty string which we want to keep
       const isEmptyValue =
@@ -215,7 +212,7 @@ const format = f.curryN(2)((column, displayValue) => {
           : f.isEmpty;
 
       const formattedValue = f.trim(isEmptyValue(dVal) ? placeholder : dVal);
-      return result.replace(moustache(colIdx), formattedValue);
+      return result.replace(moustache(colId), formattedValue);
     };
 
     const formattedString =


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

Beinhaltet die Frontendanpassungen zu [#1152: Formatpatterns bei concat-columns/links](https://app.activecollab.com/116706/projects/2/tasks/61988)

Kann zusammen mit dem [Backend-PR](https://github.com/campudus/tableaux/pull/296) getestet werden:
  - Tabelle updaten mit einem `concatFormatPattern`, welches alle identifier-Spalten beinhaltet (bspw. `"{{1}} | {{2}}"`)
 
<img width="983" alt="Bildschirmfoto 2025-03-07 um 11 27 43" src="https://github.com/user-attachments/assets/c1002558-2aaf-4ef7-8625-82bd8cf259e7" />


