### PR TITLE
AC#1161/fix annotation delete

### DIFF
--- a/src/app/redux/actions/annotationActions.js
+++ b/src/app/redux/actions/annotationActions.js
@@ -115,7 +115,6 @@ const getRequestParam = change => (cell, annotationObj) => {
     f.prop("annotation"),
     annotationObj
   );
-  if (change === Change.DELETE && param) return null;
   const apiRoute =
     route.toCell({
       tableId: table.id,


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary
In ES5 wir aus dem Code
```
if (a) return null;
var a = {};
return a;
```
was implizit verstanden wird als:
```
var a;
if (a) return null;
a = {};
return a;
```
d.h. da `a` immer falsy ist wird das `if` einfach übersprungen. (und daher auch entfernt werden).

Mit Vite haben wir einen höheren build-output target als ES5, d.h. im Build-Output wird statt `var` `const` verwendet:

``` 
if (a) return null;
const a = {};
return a;
```

Mit `const` kommt es hier zu einem Fehler ("use before declaration").
