### PR TITLE
AC#1163: Fix crash on opening "save filter" dialog

### DIFF
--- a/src/app/components/header/filter/FilterSavingPopup.jsx
+++ b/src/app/components/header/filter/FilterSavingPopup.jsx
@@ -1,8 +1,8 @@
 import i18n from "i18next";
 import f from "lodash/fp";
 import PropTypes from "prop-types";
-import React, { useCallback, useState } from "react";
-import listensToClickOutside from "react-onclickoutside";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { outsideClickEffect } from "../../../helpers/useOutsideClick";
 
 const FilterSavingPopup = ({ filters, onClose, onSubmit }) => {
   const [title, setTitle] = useState("");
@@ -26,10 +26,7 @@ const FilterSavingPopup = ({ filters, onClose, onSubmit }) => {
   });
 
   return (
-    <div
-      className="save-template-popup"
-      onClick={event => void event.stopPropagation()}
-    >
+    <div className="save-template-popup">
       <header className="save-template-popup__header">
         {i18n.t("table:filter.save-filter")}
       </header>
@@ -83,7 +80,8 @@ export const RestoreSavedFiltersArea = ({
   columns,
   onSubmit,
   storedFilters,
-  onClear
+  onClear,
+  onClose
 }) => {
   const columnNames = new Set(columns.map(col => col.name));
   const isValidTemplate = isApplicable(columnNames);
@@ -97,8 +95,17 @@ export const RestoreSavedFiltersArea = ({
   const templates = getGoodTemplates(storedFilters);
   const clearTemplate = name => void onClear(name);
 
+  const container = useRef();
+  useEffect(() => {
+    outsideClickEffect({
+      shouldListen: true,
+      containerRef: container,
+      onOutsideClick: onClose
+    });
+  }, [container.current]);
+
   return (
-    <section className="stored-filters-area">
+    <section className="stored-filters-area" ref={container}>
       <header className="filter-popup__header">
         <span className="filter-popup__heading">Gespeicherte Filter</span>
       </header>
@@ -125,7 +132,7 @@ export const RestoreSavedFiltersArea = ({
   );
 };
 
-export default listensToClickOutside(FilterSavingPopup);
+export default FilterSavingPopup;
 FilterSavingPopup.propTypes = {
   filters: PropTypes.array.isRequired,
   onClose: PropTypes.func.isRequired

--- a/src/app/components/header/filter/FilterSavingPopup.jsx
+++ b/src/app/components/header/filter/FilterSavingPopup.jsx
@@ -5,6 +5,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { outsideClickEffect } from "../../../helpers/useOutsideClick";
 
 const FilterSavingPopup = ({ filters, onClose, onSubmit }) => {
+  const container = useRef();
   const [title, setTitle] = useState("");
   const handleTitleChange = useCallback(event => setTitle(event.target.value));
 
@@ -24,9 +25,18 @@ const FilterSavingPopup = ({ filters, onClose, onSubmit }) => {
       }
     }
   });
+  
+  useEffect(
+    outsideClickEffect({
+      shouldListen: true,
+      containerRef: container,
+      onOutsideClick: onClose
+    }),
+    [container.current]
+  );
 
   return (
-    <div className="save-template-popup">
+    <div className="save-template-popup" ref={container}>
       <header className="save-template-popup__header">
         {i18n.t("table:filter.save-filter")}
       </header>
@@ -80,8 +90,7 @@ export const RestoreSavedFiltersArea = ({
   columns,
   onSubmit,
   storedFilters,
-  onClear,
-  onClose
+  onClear
 }) => {
   const columnNames = new Set(columns.map(col => col.name));
   const isValidTemplate = isApplicable(columnNames);
@@ -95,17 +104,8 @@ export const RestoreSavedFiltersArea = ({
   const templates = getGoodTemplates(storedFilters);
   const clearTemplate = name => void onClear(name);
 
-  const container = useRef();
-  useEffect(() => {
-    outsideClickEffect({
-      shouldListen: true,
-      containerRef: container,
-      onOutsideClick: onClose
-    });
-  }, [container.current]);
-
   return (
-    <section className="stored-filters-area" ref={container}>
+    <section className="stored-filters-area">
       <header className="filter-popup__header">
         <span className="filter-popup__heading">Gespeicherte Filter</span>
       </header>

--- a/src/app/components/header/tableSettings/NameEditor.jsx
+++ b/src/app/components/header/tableSettings/NameEditor.jsx
@@ -1,27 +1,26 @@
 import React, { useState, useCallback, useEffect, useRef } from "react";
 import i18n from "i18next";
-import listensToClickOutside from "react-onclickoutside";
 
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import { getTableDisplayName } from "../../../helpers/multiLanguage";
 import { preventDefault, stopPropagation } from "../../../helpers/functools";
+import { outsideClickEffect } from "../../../helpers/useOutsideClick";
 
-const NameEditorInput = listensToClickOutside(
-  ({ onChange, onKeyDown, value }) => (
-    <input
-      type="text"
-      className="input"
-      value={value}
-      autoFocus
-      onKeyDown={onKeyDown}
-      onChange={onChange}
-    />
-  )
+const NameEditorInput = ({ onChange, onKeyDown, value }) => (
+  <input
+    type="text"
+    className="input"
+    value={value}
+    autoFocus
+    onKeyDown={onKeyDown}
+    onChange={onChange}
+  />
 );
 
 const NameEditor = ({ table, langtag, changeTableName, locked }) => {
+  const container = useRef();
   const [editMode, setEditMode] = useState(false);
 
   const exitEditMode = useCallback(() => setEditMode(false));
@@ -69,17 +68,25 @@ const NameEditor = ({ table, langtag, changeTableName, locked }) => {
     active: editMode
   });
 
+  useEffect(
+    outsideClickEffect({
+      shouldListen: true,
+      containerRef: container,
+      onOutsideClick: saveAndClose
+    }),
+    [container.current]
+  );
+
   return (
-    <button className={cssClass} onClick={enterEditMode}>
+    <button className={cssClass} onClick={enterEditMode} ref={container}>
       {editMode ? (
         <NameEditorInput
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           value={value}
-          handleClickOutside={saveAndClose}
         />
       ) : (
-        <span> {i18n.t("table:editor.rename_table")} </span>
+        i18n.t("table:editor.rename_table")
       )}
     </button>
   );

--- a/src/app/components/header/tableSettings/TableSettings.jsx
+++ b/src/app/components/header/tableSettings/TableSettings.jsx
@@ -47,7 +47,7 @@ class TableSettings extends React.Component {
             <TableSettingsPopup
               table={this.props.table}
               langtag={this.props.langtag}
-              handleClickOutside={this.onClickOutside}
+              onClose={this.onClickOutside}
               actions={this.props.actions}
             />
           ) : null}

--- a/src/app/components/header/tableSettings/TableSettingsPopup.jsx
+++ b/src/app/components/header/tableSettings/TableSettingsPopup.jsx
@@ -2,9 +2,8 @@
  * Content for the TableSettings menu. Entries are individual React items with specific functions.
  */
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import i18n from "i18next";
-import listensToClickOutside from "react-onclickoutside";
 
 import PropTypes from "prop-types";
 
@@ -13,18 +12,31 @@ import {
   canUserEditRowAnnotations
 } from "../../../helpers/accessManagementHelper";
 import NameEditor from "./NameEditor";
+import { outsideClickEffect } from "../../../helpers/useOutsideClick";
 
 const TableSettingsPopup = ({
   table,
   langtag,
-  actions: { setAllRowsFinal, changeTableName }
+  actions: { setAllRowsFinal, changeTableName },
+  onClose
 }) => {
+  const container = useRef();
   const canEditRowAnnotations = canUserEditRowAnnotations({ table });
   const canEditTableDisplayProperty = canUserEditTableDisplayProperty({
     table
   });
+
+  useEffect(
+    outsideClickEffect({
+      shouldListen: true,
+      containerRef: container,
+      onOutsideClick: onClose
+    }),
+    [container.current]
+  );
+
   return (
-    <div id="table-settings-popup">
+    <div id="table-settings-popup" ref={container}>
       <button
         key="i-need-no-key"
         className={
@@ -48,7 +60,6 @@ const TableSettingsPopup = ({
 TableSettingsPopup.propTypes = {
   table: PropTypes.object.isRequired,
   langtag: PropTypes.string.isRequired,
-  handleClickOutside: PropTypes.func.isRequired
 };
 
-export default listensToClickOutside(TableSettingsPopup);
+export default TableSettingsPopup;

--- a/src/app/components/markdownEditor/LinkEditor.jsx
+++ b/src/app/components/markdownEditor/LinkEditor.jsx
@@ -1,117 +1,123 @@
 import { EditorState, RichUtils } from "draft-js";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import i18n from "i18next";
-import listensToClickOutsice from "react-onclickoutside";
 
 import PropTypes from "prop-types";
 
 import { StyleIcon } from "./StyleControls";
 import { either } from "../../helpers/functools";
+import { outsideClickEffect } from "../../helpers/useOutsideClick";
 
-const UrlInput = listensToClickOutsice(
-  ({ setLinkUrl, editorState, handleClickOutside }) => {
-    const getUrlAtPoint = selection => {
-      if (!selection.isCollapsed()) {
-        // Adapted from DraftJS link example
-        // https://github.com/facebook/draft-js/blob/ceaeebf1f50fee452d92d71c5e2008e3d4fb6d9f/examples/draft-0-10-0/link/link.html#L76
-        const content = editorState.getCurrentContent();
-        const startKey = selection.getStartKey();
-        const startOffset = selection.getStartOffset();
-        const blockWithLinkAtBeginning = content.getBlockForKey(startKey);
-        const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
-
-        const url = linkKey ? content.getEntity(linkKey).getData().url : "";
-        return url;
-      } else {
-        return "";
-      }
-    };
-
-    const extractSelectedText = selection => {
+const UrlInput = ({ setLinkUrl, editorState, onClose }) => {
+  const container = useRef();
+  const getUrlAtPoint = selection => {
+    if (!selection.isCollapsed()) {
+      // Adapted from DraftJS link example
+      // https://github.com/facebook/draft-js/blob/ceaeebf1f50fee452d92d71c5e2008e3d4fb6d9f/examples/draft-0-10-0/link/link.html#L76
       const content = editorState.getCurrentContent();
       const startKey = selection.getStartKey();
       const startOffset = selection.getStartOffset();
-      const endOffset = selection.getEndOffset();
-      const contentBlock = content.getBlockForKey(startKey);
-      return either(contentBlock)
-        .map(block => block.getText())
-        .map(string => string.slice(startOffset, endOffset))
-        .getOrElse("");
-    };
+      const blockWithLinkAtBeginning = content.getBlockForKey(startKey);
+      const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
 
-    const [url, setUrl] = React.useState(
-      either(editorState.getSelection())
-        .map(getUrlAtPoint)
-        .getOrElse("")
-    );
-    const linkTitle = extractSelectedText(editorState.getSelection());
-    const handleChange = React.useCallback(event => setUrl(event.target.value));
-    const closeInput = handleClickOutside;
-    const handleKeyDown = React.useCallback(
-      event => event.key === "Enter" && setLinkUrl(url),
-      [url]
-    );
+      const url = linkKey ? content.getEntity(linkKey).getData().url : "";
+      return url;
+    } else {
+      return "";
+    }
+  };
 
-    return (
-      <div className="link-editor-popup">
-        <header className="link-editor__header">
-          <i className="link-editor__header-icon fa fa-link" />
-          {i18n.t("table:link-editor.headline")}
-        </header>
-        <section className="link-editor__body">
-          <div className="link-editor-body__placeholder col-one row-one" />
-          <div className="link-editor-body__heading col-two row-one">
-            {i18n.t("table:link-editor.enter-link")}
-          </div>
-          <div className="link-editor-body__label col-one row-two">
-            <div className="link-editor-label__text">
-              {i18n.t("common:url")}
-            </div>
-          </div>
-          <input
-            placeholder="https://"
-            className="link-editor__input right col-two row-two"
-            type="text"
-            value={url}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-          />
-          <div className="link-editor-body__label col-one row-three">
-            <div className="link-editor-label__text">
-              {i18n.t("table:link-editor.linked-text")}
-            </div>
-          </div>
-          <input
-            placeholder={i18n.t("common:url")}
-            className="link-editor__input col-two row-three"
-            type="text"
-            value={linkTitle}
-            disabled={true}
-          />
-        </section>
-        <footer className="link-editor__footer">
-          <button
-            className="link-editor__cancel-button button neutral"
-            onClick={closeInput}
-          >
-            {i18n.t("common:cancel")}
-          </button>
+  const extractSelectedText = selection => {
+    const content = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const startOffset = selection.getStartOffset();
+    const endOffset = selection.getEndOffset();
+    const contentBlock = content.getBlockForKey(startKey);
+    return either(contentBlock)
+      .map(block => block.getText())
+      .map(string => string.slice(startOffset, endOffset))
+      .getOrElse("");
+  };
 
-          <button
-            className="link-editor__confirm-button button"
-            onClick={() => setLinkUrl(url)}
-          >
-            {i18n.t("table:link-editor.insert-link")}
-          </button>
-        </footer>
-      </div>
-    );
-  }
-);
+  const [url, setUrl] = React.useState(
+    either(editorState.getSelection())
+      .map(getUrlAtPoint)
+      .getOrElse("")
+  );
+  const linkTitle = extractSelectedText(editorState.getSelection());
+  const handleChange = React.useCallback(event => setUrl(event.target.value));
+  const handleKeyDown = React.useCallback(
+    event => event.key === "Enter" && setLinkUrl(url),
+    [url]
+  );
+
+  useEffect(
+    outsideClickEffect({
+      shouldListen: true,
+      containerRef: container,
+      onOutsideClick: onClose
+    }),
+    [container.current]
+  );
+
+  return (
+    <div className="link-editor-popup" ref={container}>
+      <header className="link-editor__header">
+        <i className="link-editor__header-icon fa fa-link" />
+        {i18n.t("table:link-editor.headline")}
+      </header>
+      <section className="link-editor__body">
+        <div className="link-editor-body__placeholder col-one row-one" />
+        <div className="link-editor-body__heading col-two row-one">
+          {i18n.t("table:link-editor.enter-link")}
+        </div>
+        <div className="link-editor-body__label col-one row-two">
+          <div className="link-editor-label__text">{i18n.t("common:url")}</div>
+        </div>
+        <input
+          placeholder="https://"
+          className="link-editor__input right col-two row-two"
+          type="text"
+          value={url}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+        />
+        <div className="link-editor-body__label col-one row-three">
+          <div className="link-editor-label__text">
+            {i18n.t("table:link-editor.linked-text")}
+          </div>
+        </div>
+        <input
+          placeholder={i18n.t("common:url")}
+          className="link-editor__input col-two row-three"
+          type="text"
+          value={linkTitle}
+          disabled={true}
+        />
+      </section>
+      <footer className="link-editor__footer">
+        <button
+          className="link-editor__cancel-button button neutral"
+          onClick={onClose}
+        >
+          {i18n.t("common:cancel")}
+        </button>
+
+        <button
+          className="link-editor__confirm-button button"
+          onClick={() => setLinkUrl(url)}
+        >
+          {i18n.t("table:link-editor.insert-link")}
+        </button>
+      </footer>
+    </div>
+  );
+};
+
 UrlInput.propTypes = {
   editorState: PropTypes.object.isRequired,
   setLinkUrl: PropTypes.func.isRequired,
-  handleClickOutside: PropTypes.func.isRequired
+  onClose: PropTypes.func.isRequired
 };
 
 const LinkEditor = ({ editorState, setEditorState }) => {
@@ -190,7 +196,7 @@ const LinkEditor = ({ editorState, setEditorState }) => {
         <UrlInput
           editorState={editorState}
           setLinkUrl={setLinkUrl}
-          handleClickOutside={handleCloseUrlInput}
+          onClose={handleCloseUrlInput}
         />
       )}
     </>

--- a/src/app/components/markdownEditor/StyleControls.jsx
+++ b/src/app/components/markdownEditor/StyleControls.jsx
@@ -26,7 +26,7 @@ export const StyleIcon = ({
     "style-button--disabled": disabled
   });
   return (
-    <div className={cssClass} onMouseDown={disabled ? f.noop : handleClick}>
+    <div className={cssClass} onClick={disabled ? f.noop : handleClick}>
       {label ? (
         <span style={{ fontWeight: "bold" }}>{label}</span>
       ) : icon ? (


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Das useOutsideClick-Paket funktioniert nur mit Klassenkomponenten. Der alte Babel/Parcel-Workflow hat alle Komponenten intern zu Klassenkomponenten transformiert, weswegen das vorher funktioniert hatte, obwohl formal falsch.