### PR TITLE
Bugfixes for numeric cells

### DIFF
--- a/src/app/components/helperComponents/NumberInput.jsx
+++ b/src/app/components/helperComponents/NumberInput.jsx
@@ -7,6 +7,18 @@ import React, {
 } from "react";
 import f from "lodash/fp";
 
+const JAVA_INT_MAX = 2_147_483_647;
+const JAVA_INT_MIN = -2_147_483_648;
+
+// Here we can use that JS uses double precicion floats to represent all numbers
+// and thus can handle bigger "integers" than Java.
+// toStorableInteger: Number -> Number
+export const toStorableInteger = f.cond([
+  [n => n > JAVA_INT_MAX, () => JAVA_INT_MAX],
+  [n => n < JAVA_INT_MIN, () => JAVA_INT_MIN],
+  [f.stubTrue, f.identity]
+]);
+
 import PropTypes from "prop-types";
 
 import {
@@ -40,7 +52,10 @@ const NumberInput = (props, ref) => {
   const thousandSeparator = decimalSeparator === "," ? "." : ",";
 
   const handleChange = event => {
-    onChange && onChange(readLocalizedNumber(event.target.value));
+    const input = readLocalizedNumber(event.target.value);
+    const isInteger = decimalDigits === 0;
+    const newValue = isInteger ? toStorableInteger(input) : input;
+    onChange && onChange(newValue);
   };
 
   const inputRef = useRef();

--- a/src/app/components/helperComponents/NumberInput.jsx
+++ b/src/app/components/helperComponents/NumberInput.jsx
@@ -28,7 +28,7 @@ import {
 } from "../../helpers/multiLanguage";
 import { doto, when } from "../../helpers/functools";
 
-const MAX_DIGITS = 14;
+export const MAX_DIGITS = 14;
 
 const NumberInput = (props, ref) => {
   const {

--- a/src/app/components/history/diffItems/NumberDiff.jsx
+++ b/src/app/components/history/diffItems/NumberDiff.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import { formatNumber } from "../../../helpers/multiLanguage";
+import { MAX_DIGITS } from "../../helperComponents/NumberInput";
 
 const NumberDiff = props => {
   const { diff, shouldFormatNumber = true } = props;
@@ -15,7 +16,9 @@ const NumberDiff = props => {
 
     return (
       <span key={idx} className={cssClass}>
-        {shouldFormatNumber ? formatNumber(value) : value}
+        {shouldFormatNumber
+          ? formatNumber(value, MAX_DIGITS, props.langtag)
+          : value}
       </span>
     );
   });


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

- Führt eine Ober- und Untergrenze für Integer-Inputs ein, so dass Werte ohne
  Exception im Backend gespeichert werden können
- Stellt sicher, dass in der History von Numeric-Werten immer alle
  Nachkommastellen angezeigt werden