### PR TITLE
GRUD_DEV-1064: Exclude C-c and C-v from blocked keys in numerics

### DIFF
--- a/src/app/components/entityView/numeric/NumericView.jsx
+++ b/src/app/components/entityView/numeric/NumericView.jsx
@@ -15,6 +15,7 @@ import { getDecimalDigits, isYearColumn } from "../../../helpers/columnHelper";
 import { maybe } from "../../../helpers/functools";
 import KeyboardShortcutsHelper from "../../../helpers/KeyboardShortcutsHelper";
 import NumberInput from "../../helperComponents/NumberInput";
+import { getModifiers } from "../../../helpers/modifierState";
 
 const enhance = compose(
   pure,
@@ -29,7 +30,7 @@ const enhance = compose(
       };
     },
     {
-      registerInput: (state, { funcs }) => node => {
+      registerInput: (_, { funcs }) => node => {
         funcs.register(node);
       },
       handleChange: () => value => {
@@ -81,7 +82,10 @@ const enhance = compose(
         "ArrowUp",
         "ArrowDown"
       ];
-      if (!f.contains(event.key, allowedKeys)) {
+      const modifier = getModifiers(event);
+      const systemKeys = ["c", "v"];
+      const isSystemCombo = modifier.mod && systemKeys.includes(event.key);
+      if (!f.contains(event.key, allowedKeys) && !isSystemCombo) {
         event.preventDefault();
         event.stopPropagation();
         return false;


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Hm. Suspicious, dass das vorher anders funktioniert haben soll…