### PR TITLE
GRUD_DEV-1143/fix intl errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ FROM node:22.14-alpine AS build
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
+ENV NODE_ENV=production
+ENV TZ=Europe/Berlin
+ENV LANG=de_DE.UTF-8
+ENV LANGUAGE=de_DE:de
+ENV LC_ALL=de_DE.UTF-8
+
 WORKDIR /usr/app
 
 COPY package*.json vite.config* tsconfig.* ./
@@ -25,6 +31,12 @@ RUN npm run lint && \
     npm prune --omit=dev
 
 FROM node:22.14-alpine
+
+ENV NODE_ENV=production
+ENV TZ=Europe/Berlin
+ENV LANG=de_DE.UTF-8
+ENV LANGUAGE=de_DE:de
+ENV LC_ALL=de_DE.UTF-8
 
 WORKDIR /usr/app
 

--- a/src/app/helpers/multiLanguage.test.js
+++ b/src/app/helpers/multiLanguage.test.js
@@ -163,10 +163,8 @@ describe("multiLanguage.js", () => {
       expect(formatNumber(1000.01, 3, "de-DE")).toMatch(decimalComma);
       expect(formatNumber(1000.01, 3, "en-US")).toMatch(decimalPoint);
 
-      expect(formatNumber(1000.01, 3, "DE")).toMatch(decimalComma);
       expect(formatNumber(1000.01, 3, "de")).toMatch(decimalComma);
       expect(formatNumber(1000.01, 3, "en")).toMatch(decimalPoint);
-      expect(formatNumber(1000.01, 3, "US")).toMatch(decimalPoint);
     });
   });
 
@@ -177,7 +175,6 @@ describe("multiLanguage.js", () => {
       expect(readLocalizedNumber("1,000", "en-US")).toBe(1000);
       expect(readLocalizedNumber("1,000.000", "en-US")).toBe(1000);
       expect(readLocalizedNumber("1,000.000", "en")).toBe(1000);
-      expect(readLocalizedNumber("1,000.000", "US")).toBe(1000);
     });
 
     it("transforms comma-separated numbers", () => {
@@ -185,7 +182,6 @@ describe("multiLanguage.js", () => {
       expect(readLocalizedNumber("1,000", "de-DE")).toBe(1);
       expect(readLocalizedNumber("1.000", "de-DE")).toBe(1000);
       expect(readLocalizedNumber("1.000,000", "de-DE")).toBe(1000);
-      expect(readLocalizedNumber("1.000,000", "DE")).toBe(1000);
       expect(readLocalizedNumber("1.000,000", "de")).toBe(1000);
     });
 


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR

Die ENV-Konfiguration für Internationalization unterscheidet sich zwischen Docker-Container und lokal.
Dadurch kommt es bei der Nutzung der [Intl-API](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl) zu unterschiedlichen Ergebnissen.

Grundsätzliches Problem ist eine Fehlannahme bzgl. locale-Resolution bei einigen Tests:
`new Intl.NumberFormat("US")` verwendet nicht wie angenommen immer das locale `en-US` zum formatieren, sondern das im System eingestellte default-locale.
Das locale kann nicht anhand der country resolved werden! ("US" oder "GB" -> default-locale; "DE" wird nur richtig resolved, weil es sich nur im Casing von "de" unterscheidet).

Das lässt sich einfach prüfen über:
  ```sh
docker run --rm node:22.14-alpine node -p 'new Intl.NumberFormat("US").resolvedOptions().locale'
# en-US
docker run -e LANG=de_DE.UTF-8 --rm node:22.14-alpine node -p 'new Intl.NumberFormat("US").resolvedOptions().locale'
# de-DE
```

Die Tests die von dieser falschen Annahme ausgehen wurden entfernt und im Dockerfile wurden defaults für die Locales und TZ aufgenommen.