### PR TITLE
fix: update vite to 6.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "sass-embedded": "1.85.1",
         "superagent": "^4.0.0",
         "typescript": "^5.8.2",
-        "vite": "6.3.4",
+        "vite": "6.3.5",
         "vite-plugin-checker": "0.9.0",
         "vitest": "3.0.7"
       }
@@ -9933,9 +9933,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
-      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sass-embedded": "1.85.1",
     "superagent": "^4.0.0",
     "typescript": "^5.8.2",
-    "vite": "6.3.4",
+    "vite": "6.3.5",
     "vite-plugin-checker": "0.9.0",
     "vitest": "3.0.7"
   },


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR
Durch das Update von Vite auf v6.3.4 gab es eine Regression dass cross-module cyclic imports auf einen Fehler laufen. ([Vitest with Vite 6.3.x regressed and started failing](https://github.com/vitest-dev/vitest/issues/7902))
Diese Regression wurde in v6.3.5 gefixt ([Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#635-2025-05-05)). 