### PR TITLE
GRUD_DEV-1143/remove NODE_ENV from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:22.14-alpine AS build
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
-ENV NODE_ENV=production
 ENV TZ=Europe/Berlin
 ENV LANG=de_DE.UTF-8
 ENV LANGUAGE=de_DE:de
@@ -32,7 +31,6 @@ RUN npm run lint && \
 
 FROM node:22.14-alpine
 
-ENV NODE_ENV=production
 ENV TZ=Europe/Berlin
 ENV LANG=de_DE.UTF-8
 ENV LANGUAGE=de_DE:de


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR
`NODE_ENV=production` unterbindet die Installation von devDependencies bei `npm i` und `npm ci`. 
Dadurch läuft der Docker Build gerade auf Fehler, weil de nötigen Dependencies für Linting und Testing nicht gefunden werden.
