### PR TITLE
GRUD_DEV-554: Use duplicate endpoint

### DIFF
--- a/src/app/components/cells/cellCopyHelper.jsx
+++ b/src/app/components/cells/cellCopyHelper.jsx
@@ -23,6 +23,7 @@ import askForSessionUnlock from "../helperComponents/SessionUnlockDialog";
 import Footer from "../overlay/Footer";
 import Header from "../overlay/Header";
 import PasteMultilanguageCellInfo from "../overlay/PasteMultilanguageCellInfo";
+import { createNewRows } from "src/app/redux/actions/rowActions";
 
 const showErrorToast = (msg, data = {}) => {
   store.dispatch(
@@ -225,7 +226,7 @@ const createEntriesAndCopy = async (src, dst, constrainedValue) => {
         )({ columns, row })
       )
     )
-    // Reduce all saveable rows into an array so we need only one POST to duplicate them
+    // Create all new links including backlinks in a single request (instead of 2N via duplicate, then changeBacklink)
     .then(
       f.reduce(
         (accum, nextRow) => ({
@@ -235,8 +236,7 @@ const createEntriesAndCopy = async (src, dst, constrainedValue) => {
         []
       )
     )
-    .then(createRowDuplicatesRequest(toTable))
-    .then(f.prop("rows"))
+    .then(cfg => createNewRows({ ...cfg, tableId: toTable.id }))
     .then(f.map(row => ({ id: row.id, value: f.first(row.values) })));
 
   changeCellValue(dst, copiedLinkValues);

--- a/src/app/components/cells/cellCopyHelper.jsx
+++ b/src/app/components/cells/cellCopyHelper.jsx
@@ -17,13 +17,13 @@ import { isTextInRange } from "../../helpers/limitTextLength";
 import { getTableDisplayName } from "../../helpers/multiLanguage";
 import P from "../../helpers/promise";
 import actions from "../../redux/actionCreators";
+import { createNewRows } from "../../redux/actions/rowActions";
 import { idsToIndices } from "../../redux/redux-helpers";
 import store from "../../redux/store";
 import askForSessionUnlock from "../helperComponents/SessionUnlockDialog";
 import Footer from "../overlay/Footer";
 import Header from "../overlay/Header";
 import PasteMultilanguageCellInfo from "../overlay/PasteMultilanguageCellInfo";
-import { createNewRows } from "src/app/redux/actions/rowActions";
 
 const showErrorToast = (msg, data = {}) => {
   store.dispatch(

--- a/src/app/redux/actions/rowActions.js
+++ b/src/app/redux/actions/rowActions.js
@@ -116,3 +116,21 @@ const addRows = (tableId, rows) => {
     rows
   };
 };
+
+export const createNewRows = ({ tableId, columns, rows }) => async dispatch => {
+  try {
+    const result = await makeRequest({
+      apiRoute: route.toTable({ tableId }),
+      data: { columns, rows },
+      method: "post"
+    });
+    dispatch({
+      type: ADDITIONAL_ROWS_DATA_LOADED,
+      tableId,
+      rows: result.rows
+    });
+    return result.rows;
+  } catch (err) {
+    return Promise.reject(new Error(`Could not create rows: ${err.message}`));
+  }
+};


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Stellt das Duplizieren von Rows auf den dedizierten `duplicate`-Endpoint um.  
Leider können wir die bisher verwendete Frontendlogik nicht entfernen, es sei denn wir nehmen in Kauf, dass Copy&Paste von Links mit Kardinalitätsbeschränkung zwei Requests pro verlinktem Wert auslösen statt einem Request pro Linkzelle.