### PR TITLE
Allow injecting permissions without auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Default project configuration can be overwritten via a `config.json` in the base
   "authServerUrl": "http://localhost:8081/auth",  // Keycloak
   "authRealm": "GRUD",                            // Keycloak realm
   "authClientId": "grud-frontend",                // Keycloak clientId
-  "disableAuth": true                             // disable authentication for frontends behind old proxy (default: false)
+  "disableAuth": true                             // disable authentication for frontends behind old proxy (default: false),
+  "injectPermissions": "path/to/perm.json"        // in dev mode, add permissions as if given by authentication and user role
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,29 @@ Following variable names can be used:
 - SHOW_TABLE_DROPDOWN=[true,false] # Show confusing table settings dropdown. Default: true
 - AUTH_SERVER_URL
 - AUTH_REALM
+- INJECT_PERMISSIONS # path to a permission JSON to mock auth results in dev mode
 
 ```sh
 PORT=3001 npm run start
 ```
+
+**Permissions JSON:**
+
+``` json
+{[key]: {[regex-template]: PermissionObject}}
+```
+
+Where `key` is one of `[columns, rows, tables ]` and `PermissionObject` is a subset of possible permissions as boolean values.  
+Routing will call `new RegExp(...)` on each `regex-template` and apply the
+permissions found at the first match when running it against the API path.
+
+**Example:**
+
+``` json
+{ columns: {".*": {changeCell: true}} }
+```
+
+Will allow editing all cells.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "markdown-draft-js": "2.4.0",
         "match-iz": "4.0.2",
         "moment": "2.29.4",
+        "node-http-proxy-json": "0.1.9",
         "postcss": "^8.5.3",
         "pragmatic-fp-ts": "^1.7.0",
         "prettier": "1.19.1",
@@ -91,10 +92,12 @@
         "rxjs": "^6.5.2",
         "sass-embedded": "1.85.1",
         "superagent": "^4.0.0",
+        "ts-import": "5.0.0-beta.1",
         "typescript": "^5.8.2",
         "vite": "6.3.5",
         "vite-plugin-checker": "0.9.0",
-        "vitest": "3.0.7"
+        "vitest": "3.0.7",
+        "zod": "3.24.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3674,9 +3677,17 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bufferhelper": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/bufferhelper/-/bufferhelper-0.2.1.tgz",
+      "integrity": "sha512-asncN5SO1YOZLCV3u26XtrbF9QXhSyq01nQOc1TFt9/gfOn7feOGJoVKk5Ewtj7wvFGPH/eGSKZ5qq/A4/PPfw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3873,6 +3884,16 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/compass-mixins": {
       "version": "0.12.12",
       "dev": true,
@@ -3890,6 +3911,22 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/connect-loki": {
       "version": "1.1.0",
@@ -3947,6 +3984,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-eslint-index": {
       "version": "1.0.0",
@@ -6920,6 +6964,17 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-http-proxy-json": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/node-http-proxy-json/-/node-http-proxy-json-0.1.9.tgz",
+      "integrity": "sha512-WrKAR/y09BWaz5WqgbxuE6D/XsdhQFkLkSdnRk0a5uBKSINtApMV085MN7JMh+stiyBBltvgSR9SYVIZIpKKKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bufferhelper": "^0.2.1",
+        "concat-stream": "^1.5.1"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7123,6 +7178,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/options-defaults": {
+      "version": "2.0.40",
+      "resolved": "https://registry.npmjs.org/options-defaults/-/options-defaults-2.0.40.tgz",
+      "integrity": "sha512-a0oW0AMaP/Uqk1gU7s3unE83wzs/MACy3wsCnNREn4wqp4KCcxRdulRjf0d2FeIxENbGJ4EBGtHTQ6J30XB6Cw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -7416,6 +7478,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/promise": {
       "version": "7.3.1",
@@ -7936,6 +8005,46 @@
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/readdirp": {
@@ -9496,6 +9605,31 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-import": {
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/ts-import/-/ts-import-5.0.0-beta.1.tgz",
+      "integrity": "sha512-EFlPc+zVN9wCkvqeg6MdOF0nKwvvHy/YXiELo+6ooNvJV/iKaHo5wJLGz8b9Cl/LhjxxB7flOtUQe6L8E2iTXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "options-defaults": "2.0.40",
+        "tslib": "2.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "5"
+      }
+    },
+    "node_modules/ts-import/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "dev": true,
@@ -9597,6 +9731,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.2",
@@ -10596,6 +10737,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "markdown-draft-js": "2.4.0",
     "match-iz": "4.0.2",
     "moment": "2.29.4",
+    "node-http-proxy-json": "0.1.9",
     "postcss": "^8.5.3",
     "pragmatic-fp-ts": "^1.7.0",
     "prettier": "1.19.1",
@@ -92,10 +93,12 @@
     "rxjs": "^6.5.2",
     "sass-embedded": "1.85.1",
     "superagent": "^4.0.0",
+    "ts-import": "5.0.0-beta.1",
     "typescript": "^5.8.2",
     "vite": "6.3.5",
     "vite-plugin-checker": "0.9.0",
-    "vitest": "3.0.7"
+    "vitest": "3.0.7",
+    "zod": "3.24.4"
   },
   "dependencies": {
     "connect-loki": "1.1.0",

--- a/server/config.js
+++ b/server/config.js
@@ -18,7 +18,8 @@ const envParams = [
   "authRealm",
   "enableHistory",
   "showTableDropdown",
-  "disableAuth"
+  "disableAuth",
+  "injectPermissions"
 ];
 
 const configDefault = {

--- a/server/dev/mockAuth.test.ts
+++ b/server/dev/mockAuth.test.ts
@@ -1,0 +1,49 @@
+import * as A from "./mockAuth";
+
+describe("auth mocking", () => {
+  describe("lookup building", () => {
+    it("should parse a config", () => {
+      const permission = A.parsePermissionObject({
+        table: { ".*": { createColumn: true } }
+      }).getValue();
+
+      const lookup = A.toSearchable(permission);
+      expect(lookup).toHaveLength(1);
+      expect(lookup[0]).toBeInstanceOf(Function);
+    });
+    it("should reject bad permission names", () => {
+      const parsed = A.parsePermissionObject({
+        table: { ".*": { createColumn: true, createHouse: true } }
+      });
+      expect(parsed.isLeft()).toBe(true);
+      //    console.log(parsed.getReason());
+      expect(JSON.parse(parsed.getReason().message)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: "unrecognized_keys" })
+        ])
+      );
+    });
+  });
+
+  describe("findInSearchable()", () => {
+    const canDeleteColumn = { delete: true };
+    const canEdit = { editCellValue: true };
+    const permissions = A.parsePermissionObject({
+      columns: { "columns/11/?$": canEdit, ".*": canDeleteColumn }
+    }).getValue();
+
+    const asSearchable = A.toSearchable(permissions);
+    const findPermission = path => A.findInSearchable(asSearchable, path);
+    describe("columns", () => {
+      it("should match any columns", () => {
+        const result = findPermission("/tables/321/columns/1723");
+        expect(result).toEqual(canDeleteColumn);
+      });
+      it("should match specific columns", () => {
+        console.log(new RegExp("columns/11/?$"));
+        const result = findPermission("/tables/321/columns/11");
+        expect(result).toEqual(canEdit);
+      });
+    });
+  });
+});

--- a/server/dev/mockAuth.ts
+++ b/server/dev/mockAuth.ts
@@ -1,0 +1,150 @@
+/**
+ * @tsImport
+ * { "mode": "compile" }
+ */
+
+import fs from "fs/promises";
+import { ServerResponse } from "http";
+import modifyResponse from "node-http-proxy-json";
+import { Either, left, right } from "pragmatic-fp-ts";
+import z from "zod";
+
+const optionalBoolean = z.boolean().optional();
+const parseTablesPermission = z
+  .object({
+    create: optionalBoolean
+  })
+  .strict();
+const parseTablePermission = z
+  .object({
+    createColumn: optionalBoolean,
+    createRow: optionalBoolean,
+    delete: optionalBoolean,
+    editCellAnnotation: optionalBoolean,
+    editDisplayProperty: optionalBoolean,
+    editRowAnnotatin: optionalBoolean,
+    editStructureProperty: optionalBoolean
+  })
+  .strict();
+const parseColumnPermission = z
+  .object({
+    delete: optionalBoolean,
+    editCellValue: z.optional(
+      z.boolean().or(z.record(z.string(), z.boolean()))
+    ),
+    editDisplayProperty: optionalBoolean,
+    editStructureProperty: optionalBoolean
+  })
+  .strict();
+const parseRowPermission = z.record(z.string(), z.boolean());
+const parseMediaPermission = z
+  .object({
+    createMedia: optionalBoolean,
+    deleteMedia: optionalBoolean,
+    editMedia: optionalBoolean
+  })
+  .strict();
+const parseServicePermssion = z
+  .object({
+    delete: optionalBoolean,
+    editDisplayProperty: optionalBoolean,
+    editStructureProperty: optionalBoolean
+  })
+  .strict();
+const parseTableGroupPermission = z
+  .object({
+    createTableGroup: optionalBoolean,
+    deleteTableGroup: optionalBoolean,
+    editTableGroup: optionalBoolean
+  })
+  .strict();
+
+const permissionSchema = z
+  .object({
+    columns: z.record(z.string(), parseColumnPermission).optional(),
+    media: z.record(z.string(), parseMediaPermission).optional(),
+    row: z.record(z.string(), parseRowPermission).optional(),
+    service: z.record(z.string(), parseServicePermssion).optional(),
+    table: z.record(z.string(), parseTablePermission).optional(),
+    tableGroup: z.record(z.string(), parseTableGroupPermission).optional(),
+    tables: z.record(z.string(), parseTablesPermission).optional()
+  })
+  .strict();
+
+export const parsePermissionObject = (x: unknown): Either<PermissionObject> => {
+  const result = permissionSchema.safeParse(x);
+  return result.success ? right(result.data) : left(result.error);
+};
+type PermissionObject = z.infer<typeof permissionSchema>;
+
+const tableBaseRE = /\/tables\/\d+\/?$/;
+const basePath: { [obj in keyof PermissionObject]: RegExp } = {
+  columns: /tables\/\d+\/columns(\/\d+\/?)?$/,
+  media: /media/,
+  row: /\/tables\/.*\/rows(\d+\/?)?$/,
+  service: /\/services\//,
+  table: tableBaseRE,
+  tableGroup: tableBaseRE,
+  tables: /\/tables\/$/
+} as const;
+
+export const toSearchable = (
+  permissions: PermissionObject
+): Array<(_: string) => Record<string, boolean>> =>
+  Object.entries(permissions).flatMap(([kind, ps]) => {
+    const base: RegExp = basePath[kind];
+    return Object.entries((ps as unknown) as Record<string, Function>).map(
+      ([reTemplate, p]) => {
+        const exact = new RegExp(reTemplate);
+        return (path: string) => {
+          const result = base.test(path) && exact.test(path) ? p : undefined;
+          console.log({
+            path,
+            reTemplate,
+            exactRe: exact,
+            base: base.test(path),
+            exact: exact.test(path),
+            result
+          });
+          return result;
+        };
+      }
+    );
+  });
+
+export const findInSearchable = (
+  lookup: ReturnType<typeof toSearchable>,
+  path: string
+) =>
+  lookup.reduce(
+    (result, matches) => result || matches(path),
+    undefined as ReturnType<typeof lookup[number]> | undefined
+  );
+
+export const injectPermissions = (permissions: PermissionObject) => {
+  {
+    const permAtPath = toSearchable(permissions);
+
+    const injectPermissionsM = (req: Request) => (
+      jsonBody?: Record<string, unknown>
+    ) => {
+      const permission = findInSearchable(permAtPath, req.url);
+      if (permission && jsonBody && typeof jsonBody === "object") {
+        jsonBody.permission = permission(req.url);
+      }
+      return jsonBody;
+    };
+    return (proxyRes: ServerResponse, req: Request, res: Response) =>
+      modifyResponse(res, proxyRes, injectPermissionsM(req));
+  }
+};
+
+export const loadPermissionConfig = (path: string): Either<PermissionObject> =>
+  fs
+    .readFile(path)
+    .then(file => file.toString())
+    .then(JSON.parse)
+    .then(parsePermissionObject)
+    .catch(err =>
+      left(new Error(`Could not read permissions from ${path}: ${err.message}`))
+    );

--- a/server/dev/mockAuth.ts
+++ b/server/dev/mockAuth.ts
@@ -73,7 +73,7 @@ const permissionSchema = z
 
 export const parsePermissionObject = (x: unknown): Either<PermissionObject> => {
   const result = permissionSchema.safeParse(x);
-  return result.success ? right(result.data) : left(result.error);
+  return result.success ? right(result.data) : left(result.error as Error);
 };
 type PermissionObject = z.infer<typeof permissionSchema>;
 
@@ -130,7 +130,7 @@ export const injectPermissions = (permissions: PermissionObject) => {
     ) => {
       const permission = findInSearchable(permAtPath, req.url);
       if (permission && jsonBody && typeof jsonBody === "object") {
-        jsonBody.permission = permission(req.url);
+        jsonBody.permission = permission;
       }
       return jsonBody;
     };

--- a/server/server.js
+++ b/server/server.js
@@ -64,7 +64,7 @@ proxy.on("proxyReq", (proxyReq, req) => {
   }
 });
 
-if (config.injectPermissions) {
+if (dev && config.injectPermissions) {
   console.log(
     "Skipping auth and injecting permissions from",
     config.injectPermissions

--- a/server/server.js
+++ b/server/server.js
@@ -64,13 +64,18 @@ proxy.on("proxyReq", (proxyReq, req) => {
   }
 });
 
-if (config.injectPermisions) {
+if (config.injectPermissions) {
+  console.log(
+    "Skipping auth and injecting permissions from",
+    config.injectPermissions
+  );
   void tsImport.load("server/dev/mockAuth.ts").then(async mockAuth => {
     const permissionConfig = await mockAuth.loadPermissionConfig(
       config.injectPermissions
     );
     if (permissionConfig.isRight()) {
-      fs.proxy.on(
+      console.log("Valid permission config found");
+      proxy.on(
         "proxyRes",
         mockAuth.injectPermissions(permissionConfig.getValue())
       );

--- a/server/server.js
+++ b/server/server.js
@@ -64,7 +64,7 @@ proxy.on("proxyReq", (proxyReq, req) => {
   }
 });
 
-if (true || config.injectPermisions) {
+if (config.injectPermisions) {
   void tsImport.load("server/dev/mockAuth.ts").then(async mockAuth => {
     const permissionConfig = await mockAuth.loadPermissionConfig(
       config.injectPermissions

--- a/src/app/constants/TableauxConstants.ts
+++ b/src/app/constants/TableauxConstants.ts
@@ -1,13 +1,14 @@
 import { Column, ColumnID, MultilangValue } from "../types/grud";
 
 type Config = {
-  disableAuth?: boolean;
+  authClientId?: string;
   authRealm?: string;
   authServerUrl?: string;
-  authClientId?: string;
-  webhookUrl: string;
-  showTableDropdown?: boolean;
+  disableAuth?: boolean;
   enableHistory?: boolean;
+  injectPermissions?: string;
+  showTableDropdown?: boolean;
+  webhookUrl: string;
 };
 
 export let config: Config;

--- a/src/app/helpers/authenticate.tsx
+++ b/src/app/helpers/authenticate.tsx
@@ -17,6 +17,8 @@ const keycloakInitOptions = {
 export const authSelector = f.propOr(false, ["grudStatus", "authenticated"]);
 
 export const noAuthNeeded = f.memoize(() => config?.disableAuth ?? false);
+export const shouldCheckPermissions =
+  !noAuthNeeded() || Boolean(config.injectPermissions);
 
 // () => Keycloak
 // Side effects: Will login on first load and memoize the result

--- a/src/app/types/permissions.ts
+++ b/src/app/types/permissions.ts
@@ -1,0 +1,40 @@
+export type TablesPermission = {
+  create?: boolean;
+};
+
+export type TablePermission = {
+  createColumn?: boolean;
+  createRow?: boolean;
+  delete?: boolean;
+  editCellAnnotation?: boolean;
+  editDisplayProperty?: boolean;
+  editRowAnnotatin?: boolean;
+  editStructureProperty?: boolean;
+};
+
+export type ColumnPermission = {
+  delete?: boolean;
+  editCellValue?: boolean | Record<string, boolean>;
+  editDisplayProperty?: boolean;
+  editStructureProperty?: boolean;
+};
+
+export type RowPermission = Record<string, boolean>; // Not defined in HackMD
+
+export type MediaPermission = {
+  createMedia?: boolean;
+  deleteMedia?: boolean;
+  editMedia?: boolean;
+};
+
+export type ServicePermission = {
+  delete?: boolean;
+  editDisplayProperty?: boolean;
+  editStructureProperty?: boolean;
+};
+
+export type TableGroupPermission = {
+  createTableGroup?: boolean;
+  deleteTableGroup?: boolean;
+  editTableGroup?: boolean;
+};


### PR DESCRIPTION
## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Ein Helper, um verschiedene Permission-Szenarien lokal testen zu können.

Wenn beim Start im Dev-Mode mit dem Parameter `INJECT_PERMISSION` ein Pfad zu
einer JSON-Datei angegeben wird, dann werden deren Einträge per RegExp auf die
aufgerufenen URLs angewendet und der erste Match als `permission`-Eintrag in die
Response injectet.  
Alles was keinen Match hat ist dann als Permission automatisch verboten.