### PR TITLE
GRUD_DEV-1148: Fokusprobleme

### DIFF
--- a/src/app/components/table/VirtualTable.jsx
+++ b/src/app/components/table/VirtualTable.jsx
@@ -512,10 +512,6 @@ class VirtualTable extends PureComponent {
   }
 
   componentDidUpdate(prev) {
-    const keys = new Set([...Object.keys(prev), Object.keys(this.props)]);
-    const changed = Array.from(keys).filter(
-      key => !f.equals(prev[key], this.props[key])
-    );
     // jump one row down if a new one was created from keyboardnavigation
     if (this.state.newRowAdded && f.size(prev.rows) < f.size(this.props.rows)) {
       tableNavigationWorker.setNextSelectedCell.call(this, Directions.DOWN);
@@ -528,7 +524,6 @@ class VirtualTable extends PureComponent {
     if (prev.columns !== this.props.columns) {
       this.cacheColumnIndices(this.props.columns);
     }
-    if (!f.isEmpty(changed)) this.focusTable();
   }
 
   cacheColumnIndices = columns => {


### PR DESCRIPTION
- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Summary

Dies scheint der minimalste Eingriff sein, der verhindert, dass aggressives
Fokussetzen das Bedienen von Popups (Fokusswitcher, Filterpopup) verhindert,
nachdem eine Zeile gelöscht wurde. Es kann dazu führen, dass in bestimmten
Edge-Cases (z.B. nach Bedienung von Overlays) jetzt nochmal auf die Tabelle
geklickt werden muss, bevor man die Tastaturnavigation wieder benutzen kann.

Usertesting ausdrücklich erwünscht!