### PR TITLE
GRUD_DEV-1166/Fix useMemo error in linkOverlay

### DIFF
--- a/src/app/components/cells/link/LinkOverlayCache.jsx
+++ b/src/app/components/cells/link/LinkOverlayCache.jsx
@@ -79,10 +79,8 @@ const withCachedLinks = Component => props => {
       });
   });
 
-  const dvLookupTable = f.compose(
-    f.keyBy("id"),
-    f.prop(["displayValues", column.toTable])
-  )(grudData);
+  const displayValues = f.prop(["displayValues", column.toTable], grudData);
+  const dvLookupTable = f.keyBy("id", displayValues);
 
   const lookupDisplayValue = link =>
     retrieveTranslation(langtag, f.prop([link.id, "values", 0], dvLookupTable));
@@ -127,7 +125,7 @@ const withCachedLinks = Component => props => {
         f.uniqBy(f.prop("id")),
         f.map(addDisplayValues)
       ),
-    [f.prop(["displayValues", column.toTable], grudData), ...cell.value]
+    [[...displayValues, ...cell.value].length]
   );
 
   const rowResults = loading


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR

Fixes useMemo-Error when adding or removing links in LinkOverlay (EntityView).

<img width="528" height="54" alt="Bildschirmfoto 2025-09-10 um 17 10 02" src="https://github.com/user-attachments/assets/12e3cfaa-64ee-45cd-961a-f2a4a0d9286a" />

