### PR TITLE
GRUD_DEV-1175/fix infinite loop after delete

### DIFF
--- a/src/app/helpers/DisplayValueWorkerControls.js
+++ b/src/app/helpers/DisplayValueWorkerControls.js
@@ -10,7 +10,7 @@ const shouldStartForTable = ({
 }) =>
   !f.isEmpty(columns) &&
   (f.isNil(allDisplayValues[table.id]) ||
-    allDisplayValues[table.id].length < rows.length) &&
+    allDisplayValues[table.id].length !== rows.length) &&
   !startedGeneratingDisplayValues &&
   finishedLoading;
 

--- a/src/app/helpers/DisplayValueWorkerControls.js
+++ b/src/app/helpers/DisplayValueWorkerControls.js
@@ -10,7 +10,7 @@ const shouldStartForTable = ({
 }) =>
   !f.isEmpty(columns) &&
   (f.isNil(allDisplayValues[table.id]) ||
-    allDisplayValues[table.id].length !== rows.length) &&
+    allDisplayValues[table.id].length < rows.length) &&
   !startedGeneratingDisplayValues &&
   finishedLoading;
 

--- a/src/app/redux/reducers/tableView.js
+++ b/src/app/redux/reducers/tableView.js
@@ -70,18 +70,23 @@ const initialState = {
   rerenderTable: ""
 };
 
-const mergeDisplayValues = (oldDisplayValues, newDisplayValues) =>
-  f.compose(
+const mergeDisplayValues = (oldDisplayValues, newDisplayValues) => {
+  const oldDisplayValueLookup = f.keyBy("id", oldDisplayValues);
+
+  return f.compose(
     f.values,
-    f.reduce((accum, { id, values }) => {
-      const oldValues = f.prop([id, "values"], accum);
+    f.reduce((accum, { id, values: newValues }) => {
+      const oldValues = f.prop([id, "values"], oldDisplayValueLookup);
       accum[id] = {
         id,
-        values: f.isEmpty(oldValues) ? values : mergeArrays(oldValues, values)
+        values: f.isEmpty(oldValues)
+          ? newValues
+          : mergeArrays(oldValues, newValues)
       };
       return accum;
     }, {})
-  )([...oldDisplayValues, ...newDisplayValues]);
+  )(newDisplayValues);
+};
 
 // This sets display values for foreign tables, allowing us to track
 // changes made by entity views onto them


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR

Nach dem Löschen eines Datensatzes läuft Redux in einen Infinite-Loop beim Generieren von DisplayValues.
Als Kriterium, ob DisplayValues generiert werden sollen dient u.A. ein Vergleich zwischen der Anzahl der Rows und der Anzahl der DisplayValues. Ist die Anzahl ungleich wird ein Update der DisplayValues angestoßen.
Nach dem Löschen einer Row ist die Anzahl nicht mehr gleich.
Beim Generieren der DisplayValues fließt aber die bereits gelöschte Row noch mit ein (alter state?, race-condition?).
D.h. nach dem Update der DisplayValues ist die Anzahl immernoch ungleich -> Infinite Loop.

Im PR wurde der Vergleich zwischen der Anzahl der Rows und der Anzahl der DisplayValues so angepasst, dass ein Update der DisplayValues nur angestoßen wird, wenn weniger DisplayValues vorhanden sind als Rows. Eine DisplayValue-"Leiche" sollte uns nicht weiter stören.