### PR TITLE
GRUD_DEV-1173/fix lookup of displayValue for rowId in filter

### DIFF
--- a/src/app/RowFilters/index.js
+++ b/src/app/RowFilters/index.js
@@ -154,11 +154,12 @@ const buildContext = (tableId, langtag, store) => {
   const rows = f.propOr([], ["rows", tableId, "data"], store);
   const displayValues = store.tableView.displayValues[tableId];
   const rowIdxLookup = buildIdxLookup("id", rows);
+  const displayValueIdxLookup = buildIdxLookup("id", displayValues);
 
   const getDisplayValueEntry = (name, row) => {
-    const rowIdx = rowIdxLookup[row.id];
+    const displayValueIdx = displayValueIdxLookup[row.id];
     const colIdx = columnIdxLookup[name];
-    return f.get(`${rowIdx}.values.${colIdx}`, displayValues);
+    return f.get(`${displayValueIdx}.values.${colIdx}`, displayValues);
   };
 
   const retrieveDisplayValue = name => row =>


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true:

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR

Nach dem Löschen einer Row wurde den nachfolgenden Rows im Filter-Kontext die falsche DisplayValue zugeordnet.
Dadurch konnte es vorkommen, dass falsche Rows im Filter angezeigt wurden.
