### PR TITLE
GRUD_DEV-1220/refactor taxonomy link display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "zod": "3.24.4"
       },
       "devDependencies": {
+        "@chenglou/pretext": "0.0.8",
         "@codemirror/lang-markdown": "6.5.0",
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
@@ -269,6 +270,13 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.3.tgz",
       "integrity": "sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==",
       "dev": true
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.11.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "Apache license 2.0",
   "devDependencies": {
+    "@chenglou/pretext": "0.0.8",
     "@codemirror/lang-markdown": "6.5.0",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/modifiers": "9.0.0",

--- a/src/app/components/cells/link/LinkCell.jsx
+++ b/src/app/components/cells/link/LinkCell.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import * as f from "lodash/fp";
+import i18n from "i18next";
 
 import PropTypes from "prop-types";
 import { compose, lifecycle } from "recompose";
@@ -14,6 +15,7 @@ import {
 import { isLocked } from "../../../helpers/rowUnlock";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { openLinkOverlay } from "./LinkOverlay";
+import { retrieveTranslation } from "../../../helpers/multiLanguage";
 
 // .link-label has a CSS max-width of 90% of .cell-content, so a single
 // label's own text can never claim the full reserved width, regardless of
@@ -24,10 +26,13 @@ const LINK_LABEL_MAX_WIDTH_RATIO = 0.9;
 // taxonomy link's displayValue is an array of {langtag: text} path nodes
 // instead of a single one, so it resolves to an array of node texts.
 const resolveCurrentLangDisplayValues = (displayValue, langtag) => {
+  const emptyValue = `(${i18n.t("common:empty").toUpperCase()})`;
   if (!displayValue) return [];
   return f.map(
     dv =>
-      f.isArray(dv) ? f.compact(f.map(f.get(langtag), dv)) : f.get(langtag, dv),
+      f.isArray(dv)
+        ? f.map(dv => retrieveTranslation(langtag, dv) || emptyValue, dv)
+        : f.get(langtag, dv),
     displayValue
   );
 };

--- a/src/app/components/cells/link/LinkCell.jsx
+++ b/src/app/components/cells/link/LinkCell.jsx
@@ -6,7 +6,11 @@ import { compose, lifecycle } from "recompose";
 
 import { withForeignDisplayValues } from "../../helperComponents/withForeignDisplayValues";
 import LinkLabelCell from "./LinkLabelCell.jsx";
-import { getVisibleLinkCount, linkReservedWidth } from "./getVisibleLinkCount";
+import {
+  cellReservedWidth,
+  getVisibleLinkCount,
+  linkReservedWidth
+} from "./getVisibleLinkCount";
 import { isLocked } from "../../../helpers/rowUnlock";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { openLinkOverlay } from "./LinkOverlay";
@@ -29,7 +33,7 @@ const resolveCurrentLangDisplayValues = (displayValue, langtag) => {
 };
 
 const getAvailableLinkLabelWidth = width =>
-  (width - linkReservedWidth) * LINK_LABEL_MAX_WIDTH_RATIO;
+  (width - cellReservedWidth - linkReservedWidth) * LINK_LABEL_MAX_WIDTH_RATIO;
 
 const LinkCell = props => {
   const {

--- a/src/app/components/cells/link/LinkCell.jsx
+++ b/src/app/components/cells/link/LinkCell.jsx
@@ -6,7 +6,7 @@ import { compose, lifecycle } from "recompose";
 
 import { withForeignDisplayValues } from "../../helperComponents/withForeignDisplayValues";
 import LinkLabelCell from "./LinkLabelCell.jsx";
-import { getVisibleLinkCount } from "./getVisibleLinkCount";
+import { getVisibleLinkCount, linkReservedWidth } from "./getVisibleLinkCount";
 import { isLocked } from "../../../helpers/rowUnlock";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { openLinkOverlay } from "./LinkOverlay";
@@ -29,7 +29,7 @@ const LinkCell = props => {
     return f.map(
       dv =>
         f.isArray(dv)
-          ? f.join(" > ", f.compact(f.map(f.get(langtag), dv))) // taxonomy link with multiple displayValues
+          ? f.compact(f.map(f.get(langtag), dv)) // taxonomy link path nodes
           : f.get(langtag, dv),
       displayValue
     );
@@ -39,6 +39,7 @@ const LinkCell = props => {
     return getVisibleLinkCount(currentLangDisplayValues, width);
   }, [currentLangDisplayValues, width]);
 
+  const availableWidth = width - linkReservedWidth;
   const isEditOrSelect = editing || selected;
   const hasMore = f.size(value) > previewLinkCount;
   const linkValues = isEditOrSelect ? value : f.take(previewLinkCount, value);
@@ -48,6 +49,7 @@ const LinkCell = props => {
       value={element}
       langtag={langtag}
       displayValue={currentLangDisplayValues[index]}
+      availableWidth={availableWidth}
       cell={cell}
     />
   ));

--- a/src/app/components/cells/link/LinkCell.jsx
+++ b/src/app/components/cells/link/LinkCell.jsx
@@ -16,6 +16,21 @@ import { openLinkOverlay } from "./LinkOverlay";
 // how much room the cell actually has.
 const LINK_LABEL_MAX_WIDTH_RATIO = 0.9;
 
+// Resolves each linked row's displayValue to the current language. A
+// taxonomy link's displayValue is an array of {langtag: text} path nodes
+// instead of a single one, so it resolves to an array of node texts.
+const resolveCurrentLangDisplayValues = (displayValue, langtag) => {
+  if (!displayValue) return [];
+  return f.map(
+    dv =>
+      f.isArray(dv) ? f.compact(f.map(f.get(langtag), dv)) : f.get(langtag, dv),
+    displayValue
+  );
+};
+
+const getAvailableLinkLabelWidth = width =>
+  (width - linkReservedWidth) * LINK_LABEL_MAX_WIDTH_RATIO;
+
 const LinkCell = props => {
   const {
     cell,
@@ -29,23 +44,17 @@ const LinkCell = props => {
   } = props;
 
   const displayValue = foreignDisplayValues || props.displayValue;
-  const currentLangDisplayValues = useMemo(() => {
-    if (!displayValue) return [];
-    return f.map(
-      dv =>
-        f.isArray(dv)
-          ? f.compact(f.map(f.get(langtag), dv)) // taxonomy link path nodes
-          : f.get(langtag, dv),
-      displayValue
-    );
-  }, [displayValue, langtag]);
+  const currentLangDisplayValues = useMemo(
+    () => resolveCurrentLangDisplayValues(displayValue, langtag),
+    [displayValue, langtag]
+  );
 
-  const previewLinkCount = useMemo(() => {
-    return getVisibleLinkCount(currentLangDisplayValues, width);
-  }, [currentLangDisplayValues, width]);
+  const previewLinkCount = useMemo(
+    () => getVisibleLinkCount(currentLangDisplayValues, width),
+    [currentLangDisplayValues, width]
+  );
 
-  const availableWidth =
-    (width - linkReservedWidth) * LINK_LABEL_MAX_WIDTH_RATIO;
+  const availableWidth = getAvailableLinkLabelWidth(width);
   const isEditOrSelect = editing || selected;
   const hasMore = f.size(value) > previewLinkCount;
   const linkValues = isEditOrSelect ? value : f.take(previewLinkCount, value);

--- a/src/app/components/cells/link/LinkCell.jsx
+++ b/src/app/components/cells/link/LinkCell.jsx
@@ -24,10 +24,20 @@ const LinkCell = props => {
   } = props;
 
   const displayValue = foreignDisplayValues || props.displayValue;
+  const currentLangDisplayValues = useMemo(() => {
+    if (!displayValue) return [];
+    return f.map(
+      dv =>
+        f.isArray(dv)
+          ? f.join(" > ", f.compact(f.map(f.get(langtag), dv))) // taxonomy link with multiple displayValues
+          : f.get(langtag, dv),
+      displayValue
+    );
+  }, [displayValue, langtag]);
+
   const previewLinkCount = useMemo(() => {
-    const currentLangDisplayValues = f.map(f.get(langtag), displayValue);
     return getVisibleLinkCount(currentLangDisplayValues, width);
-  }, [width]);
+  }, [currentLangDisplayValues, width]);
 
   const isEditOrSelect = editing || selected;
   const hasMore = f.size(value) > previewLinkCount;
@@ -37,7 +47,7 @@ const LinkCell = props => {
       key={element.id}
       value={element}
       langtag={langtag}
-      displayValue={displayValue[index]}
+      displayValue={currentLangDisplayValues[index]}
       cell={cell}
     />
   ));

--- a/src/app/components/cells/link/LinkCell.jsx
+++ b/src/app/components/cells/link/LinkCell.jsx
@@ -11,6 +11,11 @@ import { isLocked } from "../../../helpers/rowUnlock";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
 import { openLinkOverlay } from "./LinkOverlay";
 
+// .link-label has a CSS max-width of 90% of .cell-content, so a single
+// label's own text can never claim the full reserved width, regardless of
+// how much room the cell actually has.
+const LINK_LABEL_MAX_WIDTH_RATIO = 0.9;
+
 const LinkCell = props => {
   const {
     cell,
@@ -39,7 +44,8 @@ const LinkCell = props => {
     return getVisibleLinkCount(currentLangDisplayValues, width);
   }, [currentLangDisplayValues, width]);
 
-  const availableWidth = width - linkReservedWidth;
+  const availableWidth =
+    (width - linkReservedWidth) * LINK_LABEL_MAX_WIDTH_RATIO;
   const isEditOrSelect = editing || selected;
   const hasMore = f.size(value) > previewLinkCount;
   const linkValues = isEditOrSelect ? value : f.take(previewLinkCount, value);

--- a/src/app/components/cells/link/LinkLabelCell.jsx
+++ b/src/app/components/cells/link/LinkLabelCell.jsx
@@ -7,6 +7,7 @@ import Empty from "../../helperComponents/emptyEntry";
 import PermissionDenied from "../../helperComponents/PermissionDenied";
 import { isLinkArchived } from "../../../archivedRows";
 import { buildClassName } from "../../../helpers/buildClassName";
+import Tooltip from "../../helperComponents/Tooltip/TooltipWithState";
 
 const LinkLabelCell = props => {
   const {
@@ -17,6 +18,8 @@ const LinkLabelCell = props => {
   } = props;
   const linkName = f.isEmpty(displayValue)
     ? retrieveTranslation(langtag, f.first(getDisplayValue(column, [value])))
+    : typeof displayValue === "string"
+    ? displayValue
     : retrieveTranslation(langtag, displayValue);
 
   const isArchived = isLinkArchived(value);
@@ -25,22 +28,22 @@ const LinkLabelCell = props => {
 
   return (
     <button className={cssClass}>
-      <div className="label-text">
-        {value.hiddenByRowPermissions ? (
-          <PermissionDenied />
-        ) : f.isEmpty(linkName) ? (
-          <Empty />
-        ) : (
-          linkName
-        )}
-      </div>
+      {value.hiddenByRowPermissions ? (
+        <PermissionDenied />
+      ) : f.isEmpty(linkName) ? (
+        <Empty />
+      ) : (
+        <Tooltip className="label-text" tooltip={linkName} offsetTop={5}>
+          {linkName}
+        </Tooltip>
+      )}
     </button>
   );
 };
 
 LinkLabelCell.propTypes = {
   value: PropTypes.object.isRequired,
-  displayValue: PropTypes.object,
+  displayValue: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   displayValues: PropTypes.array,
   cell: PropTypes.object.isRequired,
   langtag: PropTypes.string.isRequired

--- a/src/app/components/cells/link/LinkLabelCell.jsx
+++ b/src/app/components/cells/link/LinkLabelCell.jsx
@@ -23,9 +23,7 @@ const LinkLabelCell = props => {
     ? retrieveTranslation(langtag, f.first(getDisplayValue(column, [value])))
     : isTaxonomyPath
     ? f.join(" > ", displayValue)
-    : typeof displayValue === "string"
-    ? displayValue
-    : retrieveTranslation(langtag, displayValue);
+    : displayValue;
 
   const isArchived = isLinkArchived(value);
 
@@ -37,17 +35,22 @@ const LinkLabelCell = props => {
         <PermissionDenied />
       ) : f.isEmpty(linkName) ? (
         <Empty />
-      ) : isTaxonomyPath ? (
+      ) : (
         <Tooltip
-          className="label-text label-text--taxonomy"
+          className={buildClassName("label-text", {
+            taxonomy: isTaxonomyPath
+          })}
           tooltip={linkName}
           offsetTop={5}
         >
-          <TaxonomyPath nodes={displayValue} availableWidth={availableWidth} />
-        </Tooltip>
-      ) : (
-        <Tooltip className="label-text" tooltip={linkName} offsetTop={5}>
-          {linkName}
+          {isTaxonomyPath ? (
+            <TaxonomyPath
+              nodes={displayValue}
+              availableWidth={availableWidth}
+            />
+          ) : (
+            linkName
+          )}
         </Tooltip>
       )}
     </button>
@@ -56,11 +59,7 @@ const LinkLabelCell = props => {
 
 LinkLabelCell.propTypes = {
   value: PropTypes.object.isRequired,
-  displayValue: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.string,
-    PropTypes.array
-  ]),
+  displayValue: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   displayValues: PropTypes.array,
   cell: PropTypes.object.isRequired,
   langtag: PropTypes.string.isRequired,

--- a/src/app/components/cells/link/LinkLabelCell.jsx
+++ b/src/app/components/cells/link/LinkLabelCell.jsx
@@ -43,7 +43,7 @@ const LinkLabelCell = props => {
           tooltip={linkName}
           offsetTop={5}
         >
-          {isTaxonomyPath ? (
+          {isTaxonomyPath && !f.isEmpty(displayValue) ? (
             <TaxonomyPath
               nodes={displayValue}
               availableWidth={availableWidth}

--- a/src/app/components/cells/link/LinkLabelCell.jsx
+++ b/src/app/components/cells/link/LinkLabelCell.jsx
@@ -8,16 +8,21 @@ import PermissionDenied from "../../helperComponents/PermissionDenied";
 import { isLinkArchived } from "../../../archivedRows";
 import { buildClassName } from "../../../helpers/buildClassName";
 import Tooltip from "../../helperComponents/Tooltip/TooltipWithState";
+import TaxonomyPath from "./TaxonomyPath";
 
 const LinkLabelCell = props => {
   const {
     langtag,
     displayValue,
     cell: { column },
-    value
+    value,
+    availableWidth
   } = props;
+  const isTaxonomyPath = f.isArray(displayValue);
   const linkName = f.isEmpty(displayValue)
     ? retrieveTranslation(langtag, f.first(getDisplayValue(column, [value])))
+    : isTaxonomyPath
+    ? f.join(" > ", displayValue)
     : typeof displayValue === "string"
     ? displayValue
     : retrieveTranslation(langtag, displayValue);
@@ -32,6 +37,14 @@ const LinkLabelCell = props => {
         <PermissionDenied />
       ) : f.isEmpty(linkName) ? (
         <Empty />
+      ) : isTaxonomyPath ? (
+        <Tooltip
+          className="label-text label-text--taxonomy"
+          tooltip={linkName}
+          offsetTop={5}
+        >
+          <TaxonomyPath nodes={displayValue} availableWidth={availableWidth} />
+        </Tooltip>
       ) : (
         <Tooltip className="label-text" tooltip={linkName} offsetTop={5}>
           {linkName}
@@ -43,10 +56,15 @@ const LinkLabelCell = props => {
 
 LinkLabelCell.propTypes = {
   value: PropTypes.object.isRequired,
-  displayValue: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  displayValue: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+    PropTypes.array
+  ]),
   displayValues: PropTypes.array,
   cell: PropTypes.object.isRequired,
-  langtag: PropTypes.string.isRequired
+  langtag: PropTypes.string.isRequired,
+  availableWidth: PropTypes.number
 };
 
 export default LinkLabelCell;

--- a/src/app/components/cells/link/LinkLabelCell.jsx
+++ b/src/app/components/cells/link/LinkLabelCell.jsx
@@ -27,33 +27,30 @@ const LinkLabelCell = props => {
 
   const isArchived = isLinkArchived(value);
 
-  const cssClass = buildClassName("link-label", { archived: isArchived });
+  const cssClass = buildClassName("link-label", {
+    archived: isArchived,
+    taxonomy: isTaxonomyPath
+  });
 
   return (
-    <button className={cssClass}>
-      {value.hiddenByRowPermissions ? (
-        <PermissionDenied />
-      ) : f.isEmpty(linkName) ? (
-        <Empty />
-      ) : (
-        <Tooltip
-          className={buildClassName("label-text", {
-            taxonomy: isTaxonomyPath
-          })}
-          tooltip={linkName}
-          offsetTop={5}
-        >
-          {isTaxonomyPath && !f.isEmpty(displayValue) ? (
+    <div className={cssClass}>
+      <div className="label-text">
+        {value.hiddenByRowPermissions ? (
+          <PermissionDenied />
+        ) : f.isEmpty(linkName) ? (
+          <Empty />
+        ) : isTaxonomyPath && !f.isEmpty(displayValue) ? (
+          <Tooltip className="taxonomy-label" tooltip={linkName} offsetTop={5}>
             <TaxonomyPath
               nodes={displayValue}
               availableWidth={availableWidth}
             />
-          ) : (
-            linkName
-          )}
-        </Tooltip>
-      )}
-    </button>
+          </Tooltip>
+        ) : (
+          linkName
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/src/app/components/cells/link/TaxonomyPath.jsx
+++ b/src/app/components/cells/link/TaxonomyPath.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useMemo } from "react";
 import PropTypes from "prop-types";
 
+import { buildClassName } from "../../../helpers/buildClassName";
 import { getTaxonomyPathLayout } from "./taxonomyPathLayout";
 
 const TaxonomyPath = ({ nodes, availableWidth }) => {
@@ -9,21 +10,35 @@ const TaxonomyPath = ({ nodes, availableWidth }) => {
     [nodes, availableWidth]
   );
 
-  return displayNodes.map((node, index) => (
-    <Fragment key={index}>
-      {index > 0 && <span className="taxonomy-path-separator"> &gt; </span>}
-      <span
-        className="taxonomy-path-node"
-        style={
-          index === 0 && firstNodeMaxWidth
-            ? { maxWidth: firstNodeMaxWidth }
-            : undefined
-        }
-      >
-        {node}
-      </span>
-    </Fragment>
-  ));
+  const lastIndex = displayNodes.length - 1;
+
+  return displayNodes.map((node, index) => {
+    const muted = index !== lastIndex;
+
+    return (
+      <Fragment key={index}>
+        {index > 0 && (
+          <span
+            className={buildClassName("taxonomy-path-separator", {
+              muted: true
+            })}
+          >
+            {" > "}
+          </span>
+        )}
+        <span
+          className={buildClassName("taxonomy-path-node", { muted })}
+          style={
+            index === 0 && firstNodeMaxWidth
+              ? { maxWidth: firstNodeMaxWidth }
+              : undefined
+          }
+        >
+          {node}
+        </span>
+      </Fragment>
+    );
+  });
 };
 
 TaxonomyPath.propTypes = {

--- a/src/app/components/cells/link/TaxonomyPath.jsx
+++ b/src/app/components/cells/link/TaxonomyPath.jsx
@@ -1,0 +1,34 @@
+import React, { Fragment, useMemo } from "react";
+import PropTypes from "prop-types";
+
+import { getTaxonomyPathLayout } from "./taxonomyPathLayout";
+
+const TaxonomyPath = ({ nodes, availableWidth }) => {
+  const { nodes: displayNodes, firstNodeMaxWidth } = useMemo(
+    () => getTaxonomyPathLayout(nodes, availableWidth),
+    [nodes, availableWidth]
+  );
+
+  return displayNodes.map((node, index) => (
+    <Fragment key={index}>
+      {index > 0 && <span className="taxonomy-path-separator"> &gt; </span>}
+      <span
+        className="taxonomy-path-node"
+        style={
+          index === 0 && firstNodeMaxWidth
+            ? { maxWidth: firstNodeMaxWidth }
+            : undefined
+        }
+      >
+        {node}
+      </span>
+    </Fragment>
+  ));
+};
+
+TaxonomyPath.propTypes = {
+  nodes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  availableWidth: PropTypes.number
+};
+
+export default TaxonomyPath;

--- a/src/app/components/cells/link/getVisibleLinkCount.js
+++ b/src/app/components/cells/link/getVisibleLinkCount.js
@@ -10,6 +10,8 @@ const linkLabelStyle = {
 const cellPaddingInPx = 10;
 const ellipsisWidthInPx = 8;
 
+export const linkReservedWidth = 2 * cellPaddingInPx + ellipsisWidthInPx;
+
 const { max } = Math;
 
 const measureLinkWidth = displayValue => {
@@ -17,7 +19,11 @@ const measureLinkWidth = displayValue => {
   Object.keys(linkLabelStyle).forEach(
     attr => (label.style[attr] = linkLabelStyle[attr])
   );
-  label.innerText = displayValue;
+  // taxonomy links keep their path nodes as an array; measure the joined
+  // (uncollapsed) text as the conservative worst case for this link's width
+  label.innerText = Array.isArray(displayValue)
+    ? displayValue.join(" > ")
+    : displayValue;
   const dom = document.body;
   dom.appendChild(label);
   const width = label.getBoundingClientRect().width + gapWidthInPx;

--- a/src/app/components/cells/link/getVisibleLinkCount.js
+++ b/src/app/components/cells/link/getVisibleLinkCount.js
@@ -1,12 +1,6 @@
-// TODO: Keep in sync with link label spacings/font
+import { measureText } from "./measureText";
+
 const gapWidthInPx = 6;
-const linkLabelStyle = {
-  padding: "6px 8px",
-  fontFammily: "Roboto",
-  fontSize: "1.3rem",
-  fontWeight: "normal",
-  position: "absolute"
-};
 const outerCellPaddingInPx = 9;
 const innerLinkPaddingInPx = 8;
 const ellipsisWidthInPx = 8;
@@ -16,22 +10,13 @@ export const linkReservedWidth =
 
 const { max } = Math;
 
+// taxonomy links keep their path nodes as an array; measure the joined
+// (uncollapsed) text as the conservative worst case for this link's width
 const measureLinkWidth = displayValue => {
-  const label = document.createElement("div");
-  Object.keys(linkLabelStyle).forEach(
-    attr => (label.style[attr] = linkLabelStyle[attr])
-  );
-  // taxonomy links keep their path nodes as an array; measure the joined
-  // (uncollapsed) text as the conservative worst case for this link's width
-  label.innerText = Array.isArray(displayValue)
+  const text = Array.isArray(displayValue)
     ? displayValue.join(" > ")
     : displayValue;
-  const dom = document.body;
-  dom.appendChild(label);
-  const width = label.getBoundingClientRect().width + gapWidthInPx;
-  dom.removeChild(label);
-
-  return width;
+  return measureText(text) + gapWidthInPx;
 };
 
 export const getVisibleLinkCount = (

--- a/src/app/components/cells/link/getVisibleLinkCount.js
+++ b/src/app/components/cells/link/getVisibleLinkCount.js
@@ -5,8 +5,8 @@ const outerCellPaddingInPx = 9;
 const innerLinkPaddingInPx = 8;
 const ellipsisWidthInPx = 8;
 
-export const linkReservedWidth =
-  2 * outerCellPaddingInPx + 2 * innerLinkPaddingInPx + ellipsisWidthInPx;
+export const cellReservedWidth = 2 * outerCellPaddingInPx + ellipsisWidthInPx;
+export const linkReservedWidth = 2 * innerLinkPaddingInPx + gapWidthInPx;
 
 const { max } = Math;
 
@@ -16,19 +16,20 @@ const measureLinkWidth = displayValue => {
   const text = Array.isArray(displayValue)
     ? displayValue.join(" > ")
     : displayValue;
-  return measureText(text) + gapWidthInPx;
+  return measureText(text) + linkReservedWidth;
 };
 
 export const getVisibleLinkCount = (
   values,
   fullWidth,
   n = 0,
-  reservedWidth = linkReservedWidth
+  reservedWidth = cellReservedWidth
 ) => {
   const availableWidth = max(0, fullWidth - reservedWidth);
   if (n >= values.length) return max(n, 1);
   const nextVal = values[n];
   const vWidth = measureLinkWidth(nextVal);
+
   return vWidth >= availableWidth
     ? max(n, 1)
     : getVisibleLinkCount(values, availableWidth - vWidth, n + 1, 0);
@@ -38,7 +39,7 @@ export const getVisibleAttachmentCount = (
   values,
   fullWidth,
   n = 0,
-  reservedWidth = linkReservedWidth
+  reservedWidth = cellReservedWidth
 ) => {
   const availableWidth = max(0, fullWidth - reservedWidth);
   if (n >= values.length) return max(n, 1);

--- a/src/app/components/cells/link/getVisibleLinkCount.js
+++ b/src/app/components/cells/link/getVisibleLinkCount.js
@@ -7,10 +7,12 @@ const linkLabelStyle = {
   fontWeight: "normal",
   position: "absolute"
 };
-const cellPaddingInPx = 10;
+const outerCellPaddingInPx = 9;
+const innerLinkPaddingInPx = 8;
 const ellipsisWidthInPx = 8;
 
-export const linkReservedWidth = 2 * cellPaddingInPx + ellipsisWidthInPx;
+export const linkReservedWidth =
+  2 * outerCellPaddingInPx + 2 * innerLinkPaddingInPx + ellipsisWidthInPx;
 
 const { max } = Math;
 
@@ -36,7 +38,7 @@ export const getVisibleLinkCount = (
   values,
   fullWidth,
   n = 0,
-  reservedWidth = 2 * cellPaddingInPx + ellipsisWidthInPx
+  reservedWidth = linkReservedWidth
 ) => {
   const availableWidth = max(0, fullWidth - reservedWidth);
   if (n >= values.length) return max(n, 1);
@@ -51,7 +53,7 @@ export const getVisibleAttachmentCount = (
   values,
   fullWidth,
   n = 0,
-  reservedWidth = 2 * cellPaddingInPx + ellipsisWidthInPx
+  reservedWidth = linkReservedWidth
 ) => {
   const availableWidth = max(0, fullWidth - reservedWidth);
   if (n >= values.length) return max(n, 1);

--- a/src/app/components/cells/link/measureText.js
+++ b/src/app/components/cells/link/measureText.js
@@ -1,0 +1,9 @@
+import { prepareWithSegments, measureNaturalWidth } from "@chenglou/pretext";
+
+// Must stay in sync with the .link-label / .label-text font styling in link.scss
+export const LINK_LABEL_FONT = "13px Roboto";
+
+// Unlike DOM-based measurement (e.g. via innerText), pretext throws on
+// non-string input instead of coercing it, so default missing text to "".
+export const measureText = (text = "", font = LINK_LABEL_FONT) =>
+  measureNaturalWidth(prepareWithSegments(text, font));

--- a/src/app/components/cells/link/taxonomyPathLayout.js
+++ b/src/app/components/cells/link/taxonomyPathLayout.js
@@ -1,0 +1,66 @@
+import { prepareWithSegments, measureNaturalWidth } from "@chenglou/pretext";
+
+// TODO: Keep in sync with .taxonomy-path-node/.link-label font styling
+const FONT = "13px Roboto";
+const SEPARATOR = " > ";
+const MIN_FIRST_NODE_WIDTH = 20;
+// pretext's canvas-based measurement can drift a few px from the actual
+// rendered width; bias toward collapsing rather than risk the browser's own
+// text-overflow ellipsis silently clipping the leaf node instead.
+const WIDTH_SAFETY_MARGIN = 8;
+
+export const TAXONOMY_ELLIPSIS = "...";
+
+const measure = text => measureNaturalWidth(prepareWithSegments(text, FONT));
+
+// Computes which taxonomy path nodes to show given the available width.
+// Collapses middle nodes right-to-left into a single "..." placeholder first;
+// if it still doesn't fit once fully collapsed, returns a maxWidth the first
+// node should be constrained to so CSS can ellipsis-truncate it further.
+export const getTaxonomyPathLayout = (nodes, rawAvailableWidth) => {
+  const availableWidth = Number.isFinite(rawAvailableWidth)
+    ? rawAvailableWidth - WIDTH_SAFETY_MARGIN
+    : rawAvailableWidth;
+
+  if (nodes.length <= 1 || !Number.isFinite(availableWidth)) {
+    return { nodes, firstNodeMaxWidth: null };
+  }
+
+  const first = nodes[0];
+  const last = nodes[nodes.length - 1];
+  const middle = nodes.slice(1, -1);
+
+  const separatorWidth = measure(SEPARATOR);
+  const firstWidth = measure(first);
+  const lastWidth = measure(last);
+  const ellipsisWidth = measure(TAXONOMY_ELLIPSIS);
+  const middleWidths = middle.map(measure);
+
+  for (let shown = middle.length; shown >= 0; shown--) {
+    const collapsed = shown < middle.length;
+    const nodeCount = 2 + shown + (collapsed ? 1 : 0);
+    const middleSum = middleWidths
+      .slice(0, shown)
+      .reduce((sum, w) => sum + w, 0);
+    const restWidth =
+      lastWidth +
+      middleSum +
+      (collapsed ? ellipsisWidth : 0) +
+      separatorWidth * (nodeCount - 1);
+    const totalWidth = firstWidth + restWidth;
+
+    if (totalWidth <= availableWidth || shown === 0) {
+      const displayNodes = collapsed
+        ? [first, ...middle.slice(0, shown), TAXONOMY_ELLIPSIS, last]
+        : nodes;
+      const overflow = totalWidth - availableWidth;
+      const firstNodeMaxWidth =
+        overflow > 0
+          ? Math.max(MIN_FIRST_NODE_WIDTH, firstWidth - overflow)
+          : null;
+      return { nodes: displayNodes, firstNodeMaxWidth };
+    }
+  }
+
+  return { nodes, firstNodeMaxWidth: null };
+};

--- a/src/app/components/cells/link/taxonomyPathLayout.js
+++ b/src/app/components/cells/link/taxonomyPathLayout.js
@@ -11,8 +11,9 @@ export const TAXONOMY_ELLIPSIS = "...";
 
 // Computes which taxonomy path nodes to show given the available width.
 // Collapses middle nodes right-to-left into a single "..." placeholder first;
-// if it still doesn't fit once fully collapsed, returns a maxWidth the first
-// node should be constrained to so CSS can ellipsis-truncate it further.
+// if it still doesn't fit once fully collapsed, shrinks the first node via a
+// maxWidth so CSS can ellipsis-truncate it further, unless that would shrink
+// it below a readable minimum, in which case the first node collapses too.
 export const getTaxonomyPathLayout = (nodes, rawAvailableWidth) => {
   const availableWidth = Number.isFinite(rawAvailableWidth)
     ? rawAvailableWidth - WIDTH_SAFETY_MARGIN
@@ -50,11 +51,20 @@ export const getTaxonomyPathLayout = (nodes, rawAvailableWidth) => {
         ? [first, ...middle.slice(0, shown), TAXONOMY_ELLIPSIS, last]
         : nodes;
       const overflow = totalWidth - availableWidth;
-      const firstNodeMaxWidth =
-        overflow > 0
-          ? Math.max(MIN_FIRST_NODE_WIDTH, firstWidth - overflow)
-          : null;
-      return { nodes: displayNodes, firstNodeMaxWidth };
+
+      if (overflow <= 0) {
+        return { nodes: displayNodes, firstNodeMaxWidth: null };
+      }
+
+      const shrunkFirstWidth = firstWidth - overflow;
+      if (shrunkFirstWidth < MIN_FIRST_NODE_WIDTH) {
+        return {
+          nodes: [TAXONOMY_ELLIPSIS, last],
+          firstNodeMaxWidth: null
+        };
+      }
+
+      return { nodes: displayNodes, firstNodeMaxWidth: shrunkFirstWidth };
     }
   }
 

--- a/src/app/components/cells/link/taxonomyPathLayout.js
+++ b/src/app/components/cells/link/taxonomyPathLayout.js
@@ -1,7 +1,5 @@
-import { prepareWithSegments, measureNaturalWidth } from "@chenglou/pretext";
+import { measureText as measure } from "./measureText";
 
-// TODO: Keep in sync with .taxonomy-path-node/.link-label font styling
-const FONT = "13px Roboto";
 const SEPARATOR = " > ";
 const MIN_FIRST_NODE_WIDTH = 20;
 // pretext's canvas-based measurement can drift a few px from the actual
@@ -10,8 +8,6 @@ const MIN_FIRST_NODE_WIDTH = 20;
 const WIDTH_SAFETY_MARGIN = 8;
 
 export const TAXONOMY_ELLIPSIS = "...";
-
-const measure = text => measureNaturalWidth(prepareWithSegments(text, FONT));
 
 // Computes which taxonomy path nodes to show given the available width.
 // Collapses middle nodes right-to-left into a single "..." placeholder first;
@@ -34,7 +30,7 @@ export const getTaxonomyPathLayout = (nodes, rawAvailableWidth) => {
   const firstWidth = measure(first);
   const lastWidth = measure(last);
   const ellipsisWidth = measure(TAXONOMY_ELLIPSIS);
-  const middleWidths = middle.map(measure);
+  const middleWidths = middle.map(text => measure(text));
 
   for (let shown = middle.length; shown >= 0; shown--) {
     const collapsed = shown < middle.length;

--- a/src/app/components/entityView/link/LinkView.jsx
+++ b/src/app/components/entityView/link/LinkView.jsx
@@ -1,4 +1,3 @@
-import { withProps } from "recompose";
 import React from "react";
 import * as f from "lodash/fp";
 import i18n from "i18next";
@@ -6,20 +5,43 @@ import i18n from "i18next";
 import PropTypes from "prop-types";
 
 import { retrieveTranslation } from "../../../helpers/multiLanguage";
-import { when } from "../../../helpers/functools";
-import Empty from "../../helperComponents/emptyEntry";
 import LinkList from "../../helperComponents/LinkList";
 import { canUserChangeCell } from "../../../helpers/accessManagementHelper";
+import { withForeignDisplayValues } from "../../helperComponents/withForeignDisplayValues";
 
 const LinkView = ({
   langtag,
   cell,
   cell: { value },
   actions,
-  linkList,
-  children
-}) =>
-  f.isEmpty(linkList) ? (
+  children,
+  foreignDisplayValues
+}) => {
+  const linkList = cell.value.map((link, idx) => {
+    const fallback = `(${i18n.t("common:empty").toUpperCase()})`;
+    const displayValue = foreignDisplayValues[idx] ?? cell.displayValue[idx];
+    const displayName = f.isArray(displayValue)
+      ? f
+          .map(dv => retrieveTranslation(langtag, dv) || fallback, displayValue)
+          .join(" > ")
+      : retrieveTranslation(langtag, displayValue) || fallback;
+
+    return {
+      label: displayName,
+      displayName,
+      linkTarget: {
+        tables: cell.tables,
+        tableId: cell.column.toTable,
+        rowId: link.id,
+        langtag
+      },
+      id: link.id,
+      value: link.value,
+      hiddenByRowPermissions: link.hiddenByRowPermissions
+    };
+  });
+
+  return f.isEmpty(linkList) ? (
     <div className="item-description">
       {i18n.t("table:empty.links")}
       {children}
@@ -38,6 +60,7 @@ const LinkView = ({
       {children}
     </div>
   );
+};
 
 LinkView.propTypes = {
   langtag: PropTypes.string.isRequired,
@@ -45,40 +68,4 @@ LinkView.propTypes = {
   actions: PropTypes.object.isRequired
 };
 
-const mkLinkList = (cell, langtag) => {
-  const translate = when(f.isPlainObject, retrieveTranslation(langtag));
-  return cell.value.map((link, idx) => {
-    const displayName = translate(cell.displayValue[idx]) || (
-      <Empty langtag={langtag} />
-    );
-
-    return {
-      label: displayName,
-      displayName,
-      linkTarget: {
-        tables: cell.tables,
-        tableId: cell.column.toTable,
-        rowId: link.id,
-        langtag
-      },
-      id: link.id,
-      value: link.value,
-      hiddenByRowPermissions: link.hiddenByRowPermissions
-    };
-  });
-};
-
-export default withProps(({ value, grudData, cell, langtag }) => {
-  const linkList = mkLinkList(cell, langtag);
-  try {
-    const displayValues = grudData.displayValues[cell.column.toTable];
-    const linkDisplayValues = value.map(({ id }) => {
-      const displayValueObject = f.find(f.propEq("id", id), displayValues);
-      return displayValueObject.values[0];
-    });
-    return { displayValues: linkDisplayValues, linkList };
-  } catch (err) {
-    // Worker is not done creating display values
-    return { displayValues: cell.displayValue || [], linkList };
-  }
-})(LinkView);
+export default withForeignDisplayValues(LinkView);

--- a/src/app/components/helperComponents/withForeignDisplayValues.jsx
+++ b/src/app/components/helperComponents/withForeignDisplayValues.jsx
@@ -5,12 +5,13 @@ import f from "lodash/fp";
 import { ColumnKinds } from "../../constants/TableauxConstants";
 import { doto, memoizeWith } from "../../helpers/functools";
 import { retrieveTranslation } from "../../helpers/multiLanguage";
+import * as t from "../taxonomy/taxonomy";
 
 const isLinkColumn = f.propEq("kind", ColumnKinds.link);
 const isConcatColumn = f.propEq("kind", ColumnKinds.concat);
 
-const getTable = f.memoize(tableId =>
-  f.prop(["tableView", "displayValues", tableId])
+const getDisplayValuesForTable = f.memoize(tableId =>
+  f.propOr([], ["tableView", "displayValues", tableId])
 );
 
 const getRow = rowId => f.find(f.propEq("id", rowId));
@@ -29,16 +30,39 @@ const flattenAndTranslate = f.curryN(2, (langtag, value = []) => {
 });
 
 const getLinkDisplayValues = ({ value, column: { toTable } }) => state => {
-  const tableDisplayValues = getTable(toTable)(state);
+  const tableDisplayValues = getDisplayValuesForTable(toTable)(state);
+  const tableDisplayValuesMap = f.keyBy("id", tableDisplayValues);
+  const linkTable = state.tables.data[toTable];
+  const linkRowIds = f.map(f.prop("id"), value);
 
-  const foreignDisplayValues = f.isEmpty(tableDisplayValues)
-    ? null
-    : f.map(
-        ({ id }) => doto(tableDisplayValues, getRow(id), f.prop(["values", 0])),
-        value
-      );
+  if (t.isTaxonomyTable(linkTable)) {
+    const taxonomyLinkRows = f.prop(["rows", toTable, "data"], state);
+    const taxonomyTreeNodes = t.tableToTreeNodes({ rows: taxonomyLinkRows });
+    const taxonomyTreeMap = f.keyBy("id", taxonomyTreeNodes);
+    const taxonomyLinkNodes = f.map(id => taxonomyTreeMap[id], linkRowIds);
+    const getPathFn = t.getPathToNode(taxonomyTreeNodes);
+    const taxonomyDisplayValues = f.map(node => {
+      const fullPath = f.concat(getPathFn(node), node);
+      const displayValues = f.map(f.prop("displayValue"), fullPath);
 
-  return { foreignDisplayValues };
+      return displayValues;
+    }, taxonomyLinkNodes);
+
+    return {
+      foreignDisplayValues: taxonomyDisplayValues
+    };
+  }
+
+  const foreignDisplayValues = f.map(
+    id => f.prop([id, "values", 0], tableDisplayValuesMap),
+    linkRowIds
+  );
+
+  return {
+    foreignDisplayValues: f.isEmpty(foreignDisplayValues)
+      ? null
+      : foreignDisplayValues
+  };
 };
 
 const getConcatDisplayValues = (
@@ -48,7 +72,7 @@ const getConcatDisplayValues = (
   const tableId = table.id;
   const tableDisplayValues = doto(
     state,
-    getTable(tableId),
+    getDisplayValuesForTable(tableId),
     getRow(row.id),
     f.prop("values")
   );
@@ -86,7 +110,7 @@ export const withForeignDisplayValues = Component => props => {
   const mapStateToProps = isConcatColumn(cell.column)
     ? getConcatDisplayValues(cell, langtag)
     : isLinkColumn(cell.column)
-    ? getLinkDisplayValues(cell)
+    ? getLinkDisplayValues(cell, langtag)
     : () => ({ foreignDisplayValues: cell.displayValue });
   const ConnectedComponent = connect(mapStateToProps)(Component);
   return <ConnectedComponent {...props} />;

--- a/src/app/redux/actionCreators.jsx
+++ b/src/app/redux/actionCreators.jsx
@@ -27,6 +27,8 @@ import {
 } from "./actions/userSettingActions";
 import actionTypes from "./actionTypes";
 import { overlayParamsSpec } from "./reducers/overlays";
+import { isLinkColumn } from "../types/guards";
+import { isTaxonomyTable } from "../components/taxonomy/taxonomy";
 
 const {
   getAllTables,
@@ -305,9 +307,28 @@ const generateDisplayValues = (rows, columns, table) => (
   };
 };
 
-const loadCompleteTable = ({ tableId, selectedRowId }) => async dispatch => {
+const loadCompleteTable = ({ tableId, selectedRowId }) => async (
+  dispatch,
+  getState
+) => {
   dispatch(setCurrentTable(tableId));
-  await dispatch(loadColumns(tableId));
+
+  const { columns } = await dispatch(loadColumns(tableId));
+
+  const tablesById = f.get(["tables", "data"], getState());
+
+  const taxonomyLinkColumns = columns.filter(
+    c => isLinkColumn(c) && isTaxonomyTable(tablesById[c.toTable])
+  );
+
+  // load data for taxonomy tables so it can be used as displayValue
+  for (const taxonomyLinkColumn of taxonomyLinkColumns) {
+    const taxonomyTableId = taxonomyLinkColumn.toTable;
+
+    await dispatch(loadColumns(taxonomyTableId));
+    await dispatch(Row.loadAllRows(taxonomyTableId));
+  }
+
   if (selectedRowId > 0) {
     dispatch(fetchSingleRow({ tableId, selectedRowId }));
   }

--- a/src/app/redux/actionCreators.jsx
+++ b/src/app/redux/actionCreators.jsx
@@ -313,20 +313,25 @@ const loadCompleteTable = ({ tableId, selectedRowId }) => async (
 ) => {
   dispatch(setCurrentTable(tableId));
 
-  const { columns } = await dispatch(loadColumns(tableId));
-
   const tablesById = f.get(["tables", "data"], getState());
-
-  const taxonomyLinkColumns = columns.filter(
-    c => isLinkColumn(c) && isTaxonomyTable(tablesById[c.toTable])
-  );
+  const columnsResponse = await dispatch(loadColumns(tableId));
+  const columns = columnsResponse.columns ?? [];
+  const taxonomyLinkColumns = f.compose(
+    f.uniqBy("id"),
+    f.filter(c => isLinkColumn(c) && isTaxonomyTable(tablesById[c.toTable]))
+  )(columns);
 
   // load data for taxonomy tables so it can be used as displayValue
   for (const taxonomyLinkColumn of taxonomyLinkColumns) {
     const taxonomyTableId = taxonomyLinkColumn.toTable;
 
-    await dispatch(loadColumns(taxonomyTableId));
-    await dispatch(Row.loadAllRows(taxonomyTableId));
+    // do not await taxonomy data, so table can render without having to wait.
+    // if taxonomy data takes longer than the rest, the fallback displayValue (only LeafNode) is used
+    // and will be replaced with full path as soon as data arrives
+    Promise.all([
+      dispatch(loadColumns(taxonomyTableId)),
+      dispatch(Row.loadAllRows(taxonomyTableId))
+    ]);
   }
 
   if (selectedRowId > 0) {

--- a/src/app/redux/reducers/tableView.js
+++ b/src/app/redux/reducers/tableView.js
@@ -397,7 +397,7 @@ export default (state = initialState, action, completeState) => {
       const currentTable = state.currentTable;
       if (!currentTable) return state;
       const { rows } = f.get(
-        ["rows", currentTable, "data"],
+        ["rows", action.tableId, "data"],
         completeState || {}
       );
       return {

--- a/src/app/redux/reducers/tableView.js
+++ b/src/app/redux/reducers/tableView.js
@@ -395,9 +395,11 @@ export default (state = initialState, action, completeState) => {
       };
     case ALL_ROWS_DATA_LOADED: {
       const currentTable = state.currentTable;
-      if (!currentTable) return state;
+      if (!currentTable || action.tableId !== currentTable) {
+        return state;
+      }
       const { rows } = f.get(
-        ["rows", action.tableId, "data"],
+        ["rows", currentTable, "data"],
         completeState || {}
       );
       return {

--- a/src/scss/cells/link.scss
+++ b/src/scss/cells/link.scss
@@ -26,6 +26,27 @@
       overflow: hidden;
       text-overflow: ellipsis;
       padding: 6px 8px;
+
+      // taxonomy paths control their own truncation per node (see
+      // .taxonomy-path-node); the container must not additionally clip with
+      // its own ellipsis, or it can hide the leaf node instead of the
+      // collapsed middle nodes.
+      &--taxonomy {
+        text-overflow: clip;
+      }
+    }
+
+    .taxonomy-path-node {
+      display: inline-block;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: bottom;
+    }
+
+    .taxonomy-path-separator {
+      white-space: pre;
     }
 
     &--archived {

--- a/src/scss/cells/link.scss
+++ b/src/scss/cells/link.scss
@@ -31,7 +31,7 @@
       // .taxonomy-path-node); the container must not additionally clip with
       // its own ellipsis, or it can hide the leaf node instead of the
       // collapsed middle nodes.
-      &--taxonomy {
+      .taxonomy-label {
         text-overflow: clip;
       }
     }
@@ -70,7 +70,7 @@
   }
 
   &:not(&.selected, &.editing) {
-    .link-label {
+    .link-label:not(.link-label--taxonomy) {
       pointer-events: none;
     }
   }

--- a/src/scss/cells/link.scss
+++ b/src/scss/cells/link.scss
@@ -43,10 +43,18 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       vertical-align: bottom;
+
+      &--muted {
+        opacity: 0.7;
+      }
     }
 
     .taxonomy-path-separator {
       white-space: pre;
+
+      &--muted {
+        opacity: 0.7;
+      }
     }
 
     &--archived {

--- a/src/scss/cells/link.scss
+++ b/src/scss/cells/link.scss
@@ -22,6 +22,7 @@
     padding: 0;
 
     .label-text {
+      white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
       padding: 6px 8px;
@@ -66,7 +67,8 @@
     gap: 8px;
   }
 
-  &.selected, &.editing {
+  &.selected,
+  &.editing {
     .media-thumbnail__image--icon {
       padding: 0 0 0 4px;
     }


### PR DESCRIPTION
# Submit a pull request

<!-- DO_NOT_DELETE [TICKET_LINK] Ticket link will be automatically added here if found in branch name, -->

**Related Ticket:** [GRUD_DEV-1220](https://campudus.myjetbrains.com/youtrack/issue/GRUD_DEV-1220)

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR

Bessere Darstellung für Taxonomy-Links:
- Anzeige vom vollständigen Pfad statt nur der Leaf-Node
  - jetzt: `Fahrrad > Race > Triathlon` 
  - vorher: `Triathlon`
- Optimierte Text-Ellipsis je nach verfügbarem Platz:
  -  `Fahrrad > ... > Triathlon`
  - `Fah... > ... > Triathlon`
  - `... > Triathlon`

<img width="430" height="82" alt="Bildschirmfoto 2026-07-28 um 12 50 46" src="https://github.com/user-attachments/assets/990f1a5a-3f35-446c-8993-1676345f9275" />

---

Zusätzliche Änderungen:
- Beim Laden der Columns und Rows der geöffneten Tabelle werden nun auch die Spalten und Rows von verlinkten Taxonomy-Tabellen geladen, da die Daten notwendig sind um die Taxonomy-Link Pfade zu resolven.
Evtl. können wir in einem nächsten Schritt das Backend erweitern, dass für Taxonomy-Links bereits der vollständige Pfad an der Row mitgeliefert wird.
- Text-Berechnungen für Preview-Link-Count und die Ellipsis Logik in den Taxonomy-Links wird nun mithilfe von [pretext](https://github.com/chenglou/pretext) gemacht statt direkt über die DOM.
Dadurch sind die Textberechnungen performanter, was sich beim Resizing von Link-Spalten bemerkbar machen sollte.